### PR TITLE
S59 cut dependencies

### DIFF
--- a/.github/workflows/test-java.yml
+++ b/.github/workflows/test-java.yml
@@ -13,8 +13,9 @@ jobs:
         with:
           java-version: 1.8
       # init maven settings such maven can consume packages from GitHub, not just maven central
-      - uses: s4u/maven-settings-action@v1
+      - uses: s4u/maven-settings-action@v1.1
         with:
+          override: true
           servers: '[{"id": "github", "username": "OWNER", "password": "${{secrets.GITHUB_TOKEN}}"}]'
       # do actual build + test run
       - name: Build with Maven

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -177,8 +177,7 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>co.worklytics</groupId>
-      <!--<groupId>com.google.appengine.tools</groupId>-->
+      <groupId>com.google.appengine.tools</groupId>
       <artifactId>appengine-pipeline</artifactId>
       <version>0.3_0</version>
       <exclusions>


### PR DESCRIPTION
### Fixes
 - cleanup and modernize dependencies, drop Python, drop Blobstore

### Change implications

 - breaking change to API? **no**
 - changes dependencies?  **yes**
