### PR TITLE
S64 public input context

### DIFF
--- a/.github/workflows/test-java.yml
+++ b/.github/workflows/test-java.yml
@@ -15,7 +15,7 @@ jobs:
       # init maven settings such maven can consume packages from GitHub, not just maven central
       - uses: s4u/maven-settings-action@v1.1
         with:
-          overide: true
+          override: true
           servers: '[{"id": "github", "username": "OWNER", "password": "${{secrets.GITHUB_TOKEN}}"}]'
       # do actual build + test run
       - name: Build with Maven

--- a/.github/workflows/test-java.yml
+++ b/.github/workflows/test-java.yml
@@ -13,8 +13,9 @@ jobs:
         with:
           java-version: 1.8
       # init maven settings such maven can consume packages from GitHub, not just maven central
-      - uses: s4u/maven-settings-action@v1
+      - uses: s4u/maven-settings-action@v1.1
         with:
+          overide: true
           servers: '[{"id": "github", "username": "OWNER", "password": "${{secrets.GITHUB_TOKEN}}"}]'
       # do actual build + test run
       - name: Build with Maven

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -41,6 +41,9 @@
       <!-- /packages portion is magic, not documented directly anywhere; docs suggest to put a specific repoId, which
            seems weird as we want to make ALL packages published under Worklytics organization available to maven -->
       <url>https://maven.pkg.github.com/worklytics/packages</url>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
     </repository>
   </repositories>
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -1,6 +1,6 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>com.google.appengine.tools</groupId>
+  <groupId>co.worklytics</groupId>
   <artifactId>appengine-mapreduce</artifactId>
   <name>App Engine MapReduce Library</name>
   <description>A user space MapReduce library for Google App Engine.
@@ -177,7 +177,7 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>com.google.appengine.tools</groupId>
+      <groupId>co.worklytics</groupId>
       <artifactId>appengine-pipeline</artifactId>
       <version>0.3_0</version>
       <exclusions>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -171,7 +171,7 @@
     <dependency>
       <groupId>co.worklytics</groupId>
       <artifactId>appengine-pipeline</artifactId>
-      <version>0.3_0</version>
+      <version>0.3-SNAPSHOT</version>
       <exclusions>
         <exclusion>
           <groupId>com.google.guava</groupId>

--- a/java/src/main/java/com/google/appengine/tools/mapreduce/Input.java
+++ b/java/src/main/java/com/google/appengine/tools/mapreduce/Input.java
@@ -21,7 +21,7 @@ public abstract class Input<I> implements Serializable {
 
   private transient Context context;
 
-  void setContext(Context context) {
+  public void setContext(Context context) {
     this.context = context;
   }
 


### PR DESCRIPTION
branches from #5 . `Input.setContext()` needs to be public. I think it's an oversight on their part.

