### PR TITLE
s67: force java8 build

### DIFF
--- a/.github/workflows/test-java.yml
+++ b/.github/workflows/test-java.yml
@@ -8,10 +8,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - name: Set up JDK 1.8
+      - name: Set up JDK 11  # first LTS version that can accept --release arg; needed so we can for compiler to use that version of bytecode
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
       # init maven settings such maven can consume packages from GitHub, not just maven central
       - uses: s4u/maven-settings-action@v1.1
         with:

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -9,6 +9,8 @@
   <organization>
     <name>Google</name>
   </organization>
+  <!-- follow semver for fork of OSS -->
+  <!-- https://gofore.com/en/best-practices-for-forking-a-git-repo/ -->
   <version>0.10+worklytics.1-SNAPSHOT</version>
   <packaging>jar</packaging>
   <scm>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -33,6 +33,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <github.global.server>github</github.global.server>
+    <jackson.version>(2.7,2.99)</jackson.version> <!-- 2.7+ is needed for JDK8 data type serialization -->
   </properties>
   <repositories>
     <repository>
@@ -79,10 +80,11 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.6.2</version>
+        <version>3.8.1</version>
         <configuration>
           <source>1.8</source> <!-- GAE doesn't support java7 from March 2019 -->
           <target>1.8</target>
+          <release>8</release>
         </configuration>
       </plugin>
       <plugin>
@@ -171,7 +173,7 @@
     <dependency>
       <groupId>com.google.appengine.tools</groupId>
       <artifactId>appengine-pipeline</artifactId>
-      <version>0.3_0</version>
+      <version>0.3-SNAPSHOT</version>
       <exclusions>
         <exclusion>
           <groupId>com.google.guava</groupId>
@@ -269,13 +271,13 @@
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-databind</artifactId>
-      <version>[2.0,2.99]</version>
-    </dependency>
-        <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>[2.0,2.99]</version>
+      <version>${jackson.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>${jackson.version}</version>
     </dependency>
     <!-- Test Dependencies -->
     <dependency>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -9,7 +9,7 @@
   <organization>
     <name>Google</name>
   </organization>
-  <version>0.10-SNAPSHOT</version>
+  <version>0.10+worklytics.1-SNAPSHOT</version>
   <packaging>jar</packaging>
   <scm>
     <connection>scm:git:git@github.com:Worklytics/appengine-mapreduce.git</connection>
@@ -173,13 +173,7 @@
     <dependency>
       <groupId>com.google.appengine.tools</groupId>
       <artifactId>appengine-pipeline</artifactId>
-      <version>0.3-SNAPSHOT</version>
-      <exclusions>
-        <exclusion>
-          <groupId>com.google.guava</groupId>
-          <artifactId>guava-jdk5</artifactId>
-        </exclusion>
-      </exclusions>
+      <version>0.3+worklytics.1</version>
     </dependency>
     <dependency>
       <groupId>com.googlecode.charts4j</groupId>


### PR DESCRIPTION
### Fixes
 - forces java8 build regardless of sdk version on machine; avoids some weird errors

### Change implications

 - breaking change to API? **no**
 - changes dependencies?  **yes** -- bumps jackson up to > 2.7, which is from 2017 ... so should be safe / needed.
