### PR TITLE
S69 support encrypted buckets

### DIFF
--- a/.github/workflows/test-java.yml
+++ b/.github/workflows/test-java.yml
@@ -22,3 +22,5 @@ jobs:
         run: |
           cd java/
           mvn test
+        env:
+          APPENGINE_MAPREDUCE_CI_SERVICE_ACCOUNT_KEY: ${{ secrets.APPENGINE_MAPREDUCE_CI_SERVICE_ACCOUNT_KEY }}

--- a/README.md
+++ b/README.md
@@ -27,10 +27,17 @@ Library for running MapReduce on Google App Engine
 
 Only Maven is currently supported.
 
-To test the library:
+### Testing
+First, set up an env variable `APPENGINE_MAPREDUCE_CI_SERVICE_ACCOUNT_KEY` as base64-encoded copy of a GCP Service
+ Account key. The service account must have admin permissions for GCS in a project for which GCS APIs are enabled. 
+   - in IntelliJ, can be set via your Run Configurations for JUnit
+   - in CI, we use a GitHub secret for this; see [.github/workflows/test-java.yml]
+ 
+Then, too test the library:
 ```shell script
 mvn test
 ```
+### Distribution
 
 To build binary for distribution:
 ```shell script

--- a/README.md
+++ b/README.md
@@ -34,7 +34,11 @@ mvn test
 
 To build binary for distribution:
 ```shell script
-mvn build
+mvn package
+```
+without tests (which take a long time):
+```shell script
+mvn package -Dmaven.test.skip=TRUE
 ```
 
 To deploy it:

--- a/java/README.md
+++ b/java/README.md
@@ -4,3 +4,8 @@ Java library for MapReduce implementation.
 
 ## Build Instructions
 
+
+## Change Log
+
+### worklytics.2
+  * migrate to modern GCS client

--- a/java/README.md
+++ b/java/README.md
@@ -8,4 +8,5 @@ Java library for MapReduce implementation.
 ## Change Log
 
 ### worklytics.2
-  * migrate to modern GCS client
+  * migrate to modern GCS client; breaking changes to all GoogleCloudStorage Input/Output classes
+  

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -188,6 +188,19 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <!-- TODO: migrate to com.google.cloud.google-cloud-storage
+    see: https://cloud.google.com/storage/docs/reference/libraries -->
+    <dependency>
+      <groupId>com.google.appengine.tools</groupId>
+      <artifactId>appengine-gcs-client</artifactId>
+      <version>[0.4.3,1.0)</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.apis</groupId>
+          <artifactId>google-api-services-storage</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
     <dependency>
       <groupId>com.google.appengine.tools</groupId>
       <artifactId>appengine-pipeline</artifactId>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -188,19 +188,6 @@
         </exclusion>
       </exclusions>
     </dependency>
-    <!-- TODO: migrate to com.google.cloud.google-cloud-storage
-    see: https://cloud.google.com/storage/docs/reference/libraries -->
-    <dependency>
-      <groupId>com.google.appengine.tools</groupId>
-      <artifactId>appengine-gcs-client</artifactId>
-      <version>[0.4.3,1.0)</version>
-      <exclusions>
-        <exclusion>
-          <groupId>com.google.apis</groupId>
-          <artifactId>google-api-services-storage</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
     <dependency>
       <groupId>com.google.appengine.tools</groupId>
       <artifactId>appengine-pipeline</artifactId>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -11,7 +11,7 @@
   </organization>
   <!-- follow semver for fork of OSS -->
   <!-- https://gofore.com/en/best-practices-for-forking-a-git-repo/ -->
-  <version>0.10+worklytics.1-SNAPSHOT</version>
+  <version>0.10+worklytics.2-SNAPSHOT</version>
   <packaging>jar</packaging>
   <scm>
     <connection>scm:git:git@github.com:Worklytics/appengine-mapreduce.git</connection>
@@ -54,6 +54,7 @@
       <url>https://maven.pkg.github.com/Worklytics/appengine-mapreduce</url>
     </repository>
   </distributionManagement>
+
   <reporting>
     <plugins>
       <plugin>
@@ -76,6 +77,18 @@
       </plugin>
     </plugins>
   </reporting>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.google.cloud</groupId>
+        <artifactId>libraries-bom</artifactId>
+        <version>5.1.0</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 
   <build>
     <plugins>
@@ -159,6 +172,22 @@
       <version>2.5</version>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+      <version>1.18.12</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-storage</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava-jdk5</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
     <!-- TODO: migrate to com.google.cloud.google-cloud-storage
     see: https://cloud.google.com/storage/docs/reference/libraries -->
     <dependency>
@@ -167,8 +196,8 @@
       <version>[0.4.3,1.0)</version>
       <exclusions>
         <exclusion>
-          <groupId>com.google.guava</groupId>
-          <artifactId>guava-jdk5</artifactId>
+          <groupId>com.google.apis</groupId>
+          <artifactId>google-api-services-storage</artifactId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/java/src/main/java/com/google/appengine/tools/mapreduce/GcpCredentialOptions.java
+++ b/java/src/main/java/com/google/appengine/tools/mapreduce/GcpCredentialOptions.java
@@ -1,0 +1,46 @@
+package com.google.appengine.tools.mapreduce;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.google.auth.Credentials;
+import com.google.auth.oauth2.ServiceAccountCredentials;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageOptions;
+import lombok.SneakyThrows;
+import lombok.ToString;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.Base64;
+import java.util.Optional;
+
+public interface GcpCredentialOptions {
+
+  String getServiceAccountKey();
+
+  /**
+   * @return Credentials to use when accessing GCS bucket
+   * @throws IOException if can't parse ServiceAccountCredentials from serviceAccountKey
+   */
+  @JsonIgnore
+  @SneakyThrows //having this explicitly throw checked IOException is annoying, not especially useful
+  default Optional<ServiceAccountCredentials> getServiceAccountCredentials() {
+    if (getServiceAccountKey() == null) {
+      return Optional.empty();
+    } else {
+      String jsonKey = new String(Base64.getDecoder().decode(getServiceAccountKey().trim().getBytes()));
+      return Optional.of(ServiceAccountCredentials.fromStream(new ByteArrayInputStream(jsonKey.getBytes())));
+    }
+  }
+
+  //helper util; consider moving to GCPUtils class, or something ...
+  static Storage getStorageClient(GcpCredentialOptions gcpCredentialOptions) {
+    Credentials credentials =
+      gcpCredentialOptions.getServiceAccountCredentials().map(c -> (Credentials) c)
+        .orElseGet(() -> StorageOptions.getDefaultInstance().getCredentials());
+
+    return StorageOptions.newBuilder()
+      .setCredentials(credentials)
+      .build().getService();
+
+  }
+}

--- a/java/src/main/java/com/google/appengine/tools/mapreduce/GcsFilename.java
+++ b/java/src/main/java/com/google/appengine/tools/mapreduce/GcsFilename.java
@@ -1,4 +1,34 @@
 package com.google.appengine.tools.mapreduce;
 
-public class GcsFilename {
+import com.google.cloud.storage.BlobId;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+
+import java.io.Serializable;
+
+/**
+ * container for a GcsFilename
+ *
+ * dropin replacement for com.google.appengine.tools.cloudstorage.GcsFilename
+ *
+ * @see com.google.appengine.tools.cloudstorage.GcsFilename
+ */
+@Getter
+@RequiredArgsConstructor
+@ToString
+public final class GcsFilename implements Serializable {
+  private static final long serialVersionUID = 1L;
+
+  @NonNull
+  private final String bucketName;
+
+  @NonNull
+  private final String objectName;
+
+  public BlobId asBlobId() {
+    return BlobId.of(getBucketName(), getObjectName());
+  }
+
 }

--- a/java/src/main/java/com/google/appengine/tools/mapreduce/GcsFilename.java
+++ b/java/src/main/java/com/google/appengine/tools/mapreduce/GcsFilename.java
@@ -1,0 +1,4 @@
+package com.google.appengine.tools.mapreduce;
+
+public class GcsFilename {
+}

--- a/java/src/main/java/com/google/appengine/tools/mapreduce/GoogleCloudStorageFileSet.java
+++ b/java/src/main/java/com/google/appengine/tools/mapreduce/GoogleCloudStorageFileSet.java
@@ -1,6 +1,5 @@
 package com.google.appengine.tools.mapreduce;
 
-import com.google.appengine.tools.cloudstorage.GcsFilename;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 

--- a/java/src/main/java/com/google/appengine/tools/mapreduce/MapJob.java
+++ b/java/src/main/java/com/google/appengine/tools/mapreduce/MapJob.java
@@ -50,6 +50,8 @@ public class MapJob<I, O, R> extends Job0<MapReduceResult<R>> {
     this.settings = settings;
   }
 
+  public static final String DEFAULT_QUEUE_NAME = "default";
+
   /**
    * Starts a {@link MapJob} with the given parameters in a new Pipeline.
    * Returns the pipeline id.
@@ -57,7 +59,7 @@ public class MapJob<I, O, R> extends Job0<MapReduceResult<R>> {
   public static <I, O, R> String start(MapSpecification<I, O, R> specification,
       MapSettings settings) {
     if (settings.getWorkerQueueName() == null) {
-      settings = new MapSettings.Builder(settings).setWorkerQueueName("default").build();
+      settings = new MapSettings.Builder(settings).setWorkerQueueName(DEFAULT_QUEUE_NAME).build();
     }
     PipelineService pipelineService = PipelineServiceFactory.newPipelineService();
     return pipelineService.startNewPipeline(
@@ -72,7 +74,7 @@ public class MapJob<I, O, R> extends Job0<MapReduceResult<R>> {
       if (queue == null) {
         log.warning("workerQueueName is null and current queue is not available in the pipeline"
             + " job, using 'default'");
-        queue = "default";
+        queue = DEFAULT_QUEUE_NAME;
       }
       settings = new MapReduceSettings.Builder().setWorkerQueueName(queue).build();
     }

--- a/java/src/main/java/com/google/appengine/tools/mapreduce/MapReduceJob.java
+++ b/java/src/main/java/com/google/appengine/tools/mapreduce/MapReduceJob.java
@@ -339,14 +339,21 @@ public class MapReduceJob<I, K, V, O, R> extends Job0<MapReduceResult<R>> {
         return immediate(priorResult);
       }
 
+      GoogleCloudStorageLineInput.BaseOptions inputOptions = GoogleCloudStorageLineInput.BaseOptions.defaults();
+      GoogleCloudStorageFileOutput.BaseOptions outputOptions = GoogleCloudStorageFileOutput.BaseOptions.defaults();
+      if (settings.getServiceAccountKey() != null) {
+        inputOptions = inputOptions.withServiceAccountKey(settings.getServiceAccountKey());
+        outputOptions = outputOptions.withServiceAccountKey(settings.getServiceAccountKey());
+      }
+
       GoogleCloudStorageMergeInput input =
-          new GoogleCloudStorageMergeInput(sortFiles, settings.getMergeFanin(), GoogleCloudStorageLineInput.BaseOptions.defaults().withServiceAccountKey(settings.getServiceAccountKey()));
+          new GoogleCloudStorageMergeInput(sortFiles, settings.getMergeFanin(), inputOptions);
       ((Input<?>) input).setContext(context);
       List<? extends InputReader<KeyValue<ByteBuffer, Iterator<ByteBuffer>>>> readers =
           input.createReaders();
 
       Output<KeyValue<ByteBuffer, List<ByteBuffer>>, FilesByShard> output =
-          new GoogleCloudStorageMergeOutput(settings.getBucketName(), mrJobId, tier, GoogleCloudStorageFileOutput.BaseOptions.defaults().withServiceAccountKey(settings.getServiceAccountKey()));
+          new GoogleCloudStorageMergeOutput(settings.getBucketName(), mrJobId, tier, outputOptions);
       output.setContext(context);
 
       List<? extends OutputWriter<KeyValue<ByteBuffer, List<ByteBuffer>>>> writers =

--- a/java/src/main/java/com/google/appengine/tools/mapreduce/MapReduceJob.java
+++ b/java/src/main/java/com/google/appengine/tools/mapreduce/MapReduceJob.java
@@ -6,7 +6,6 @@ package com.google.appengine.tools.mapreduce;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import com.google.appengine.tools.cloudstorage.GcsFilename;
 import com.google.appengine.tools.mapreduce.impl.BaseContext;
 import com.google.appengine.tools.mapreduce.impl.CountersImpl;
 import com.google.appengine.tools.mapreduce.impl.FilesByShard;

--- a/java/src/main/java/com/google/appengine/tools/mapreduce/MapReduceJob.java
+++ b/java/src/main/java/com/google/appengine/tools/mapreduce/MapReduceJob.java
@@ -282,7 +282,7 @@ public class MapReduceJob<I, K, V, O, R> extends Job0<MapReduceResult<R>> {
           new ShardedJob<>(shardedJobId, sortTasks.build(), workerController, shardedJobSettings);
       FutureValue<Void> shardedJobResult = futureCall(shardedJob, settings.toJobSettings());
 
-      return futureCall(new ExamineStatusAndReturnResult<FilesByShard>(shardedJobId),
+      return futureCall(new ExamineStatusAndReturnResult<>(shardedJobId),
           resultAndStatus, settings.toJobSettings(waitFor(shardedJobResult),
               statusConsoleUrl(shardedJobSettings.getMapReduceStatusUrl())));
     }
@@ -335,6 +335,7 @@ public class MapReduceJob<I, K, V, O, R> extends Job0<MapReduceResult<R>> {
       FilesByShard sortFiles = priorResult.getOutputResult();
       int maxFilesPerShard = findMaxFilesPerShard(sortFiles);
       if (maxFilesPerShard <= settings.getMergeFanin()) {
+        //no merge needed
         return immediate(priorResult);
       }
 

--- a/java/src/main/java/com/google/appengine/tools/mapreduce/MapReduceJob.java
+++ b/java/src/main/java/com/google/appengine/tools/mapreduce/MapReduceJob.java
@@ -31,6 +31,7 @@ import com.google.appengine.tools.mapreduce.impl.sort.MergeShardTask;
 import com.google.appengine.tools.mapreduce.impl.sort.SortContext;
 import com.google.appengine.tools.mapreduce.impl.sort.SortShardTask;
 import com.google.appengine.tools.mapreduce.impl.sort.SortWorker;
+import com.google.appengine.tools.mapreduce.outputs.GoogleCloudStorageFileOutput;
 import com.google.appengine.tools.pipeline.FutureValue;
 import com.google.appengine.tools.pipeline.Job0;
 import com.google.appengine.tools.pipeline.Job1;
@@ -139,7 +140,11 @@ public class MapReduceJob<I, K, V, O, R> extends Job0<MapReduceResult<R>> {
               mrJobId,
               mrSpec.getKeyMarshaller(),
               mrSpec.getValueMarshaller(),
-              new HashingSharder(getNumOutputFiles(readers.size())));
+              new HashingSharder(getNumOutputFiles(readers.size())),
+              GoogleCloudStorageFileOutput.BaseOptions.builder()
+                .credentials(settings.getStorageCredentials())
+                .build()
+      );
       output.setContext(context);
 
       List<? extends OutputWriter<KeyValue<K, V>>> writers = output.createWriters(readers.size());

--- a/java/src/main/java/com/google/appengine/tools/mapreduce/MapReduceSettings.java
+++ b/java/src/main/java/com/google/appengine/tools/mapreduce/MapReduceSettings.java
@@ -7,6 +7,7 @@ import com.google.appengine.api.appidentity.AppIdentityServiceFailureException;
 
 import com.google.auth.Credentials;
 import com.google.auth.oauth2.GoogleCredentials;
+import com.google.auth.oauth2.ServiceAccountCredentials;
 import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.Storage;
@@ -35,7 +36,7 @@ import java.util.logging.Logger;
  * @author ohler@google.com (Christian Ohler)
  */
 @ToString
-public class MapReduceSettings extends MapSettings {
+public class MapReduceSettings extends MapSettings implements GcpCredentialOptions {
 
   private static final long serialVersionUID = 610088354289299175L;
   private static final Logger log = Logger.getLogger(MapReduceSettings.class.getName());
@@ -68,7 +69,7 @@ public class MapReduceSettings extends MapSettings {
    * some risk of exposure.
    */
   @Getter
-  private final Credentials storageCredentials;
+  private final String serviceAccountKey;
 
   public static class Builder extends BaseBuilder<Builder> {
 
@@ -79,7 +80,7 @@ public class MapReduceSettings extends MapSettings {
     private int sortBatchPerEmitBytes = DEFAULT_SORT_BATCH_PER_EMIT_BYTES;
     private int mergeFanin = DEFAULT_MERGE_FANIN;
     @Getter
-    private Credentials storageCredentials;
+    private String serviceAccountKey;
 
     public Builder() {}
 
@@ -92,7 +93,7 @@ public class MapReduceSettings extends MapSettings {
       this.sortReadTimeMillis = settings.sortReadTimeMillis;
       this.sortBatchPerEmitBytes = settings.sortBatchPerEmitBytes;
       this.mergeFanin = settings.mergeFanin;
-      this.storageCredentials = settings.storageCredentials;
+      this.serviceAccountKey = settings.serviceAccountKey;
     }
 
     public Builder(MapSettings settings) {
@@ -177,8 +178,8 @@ public class MapReduceSettings extends MapSettings {
     /**
      * credentials to use when accessing storage for sort/shuffle phases of this MR j
      */
-    public Builder setStorageCredentials(Credentials credentials) {
-      this.storageCredentials = credentials;
+    public Builder setServiceAccountKey(String serviceAccountKey) {
+      this.serviceAccountKey = serviceAccountKey;
       return this;
     }
 
@@ -194,7 +195,7 @@ public class MapReduceSettings extends MapSettings {
     sortReadTimeMillis = builder.sortReadTimeMillis;
     sortBatchPerEmitBytes = builder.sortBatchPerEmitBytes;
     mergeFanin = builder.mergeFanin;
-    storageCredentials = builder.storageCredentials;
+    serviceAccountKey = builder.serviceAccountKey;
     bucketName = Optional.ofNullable(Strings.emptyToNull(builder.bucketName))
       .orElseGet(AppIdentityServiceFactory.getAppIdentityService()::getDefaultGcsBucketName);
 

--- a/java/src/main/java/com/google/appengine/tools/mapreduce/MapReduceSettings.java
+++ b/java/src/main/java/com/google/appengine/tools/mapreduce/MapReduceSettings.java
@@ -14,6 +14,7 @@ import com.google.cloud.storage.StorageOptions;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import lombok.Getter;
+import lombok.Setter;
 import lombok.SneakyThrows;
 import lombok.ToString;
 
@@ -169,6 +170,14 @@ public class MapReduceSettings extends MapSettings {
      */
     public Builder setMergeFanin(int mergeFanin) {
       this.mergeFanin = mergeFanin;
+      return this;
+    }
+
+    /**
+     * credentials to use when accessing storage for sort/shuffle phases of this MR j
+     */
+    public Builder setStorageCredentials(Credentials credentials) {
+      this.storageCredentials = credentials;
       return this;
     }
 

--- a/java/src/main/java/com/google/appengine/tools/mapreduce/MapReduceSettings.java
+++ b/java/src/main/java/com/google/appengine/tools/mapreduce/MapReduceSettings.java
@@ -92,7 +92,7 @@ public class MapReduceSettings extends MapSettings {
       this.sortReadTimeMillis = settings.sortReadTimeMillis;
       this.sortBatchPerEmitBytes = settings.sortBatchPerEmitBytes;
       this.mergeFanin = settings.mergeFanin;
-      this.storageCredentials = GoogleCredentials.getApplicationDefault();
+      this.storageCredentials = settings.storageCredentials;
     }
 
     public Builder(MapSettings settings) {

--- a/java/src/main/java/com/google/appengine/tools/mapreduce/MapSettings.java
+++ b/java/src/main/java/com/google/appengine/tools/mapreduce/MapSettings.java
@@ -22,6 +22,10 @@ import com.google.appengine.tools.mapreduce.impl.shardedjob.ShardedJobSettings;
 import com.google.appengine.tools.pipeline.JobSetting;
 import com.google.appengine.tools.pipeline.impl.servlets.PipelineServlet;
 import com.google.common.base.Preconditions;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
 
 import java.io.Serializable;
 import java.util.concurrent.Callable;
@@ -33,6 +37,8 @@ import java.util.concurrent.Callable;
  * different backends, modules or different base urls have different versions of the code).
  */
 @SuppressWarnings("deprecation")
+@ToString
+@RequiredArgsConstructor
 public class MapSettings implements Serializable {
 
   private static final long serialVersionUID = 51425056338041064L;

--- a/java/src/main/java/com/google/appengine/tools/mapreduce/bigqueryjobs/BigQueryLoadFileSetJob.java
+++ b/java/src/main/java/com/google/appengine/tools/mapreduce/bigqueryjobs/BigQueryLoadFileSetJob.java
@@ -6,7 +6,7 @@ import com.google.api.services.bigquery.model.JobConfiguration;
 import com.google.api.services.bigquery.model.JobConfigurationLoad;
 import com.google.api.services.bigquery.model.TableReference;
 import com.google.api.services.bigquery.model.TableSchema;
-import com.google.appengine.tools.cloudstorage.GcsFilename;
+import com.google.appengine.tools.mapreduce.GcsFilename;
 import com.google.appengine.tools.mapreduce.impl.BigQueryConstants;
 import com.google.appengine.tools.mapreduce.impl.util.SerializableValue;
 import com.google.appengine.tools.pipeline.ImmediateValue;
@@ -24,7 +24,7 @@ import java.util.logging.Logger;
  * status and retries or cleans up the files based on the status of the load job.
  */
 final class BigQueryLoadFileSetJob extends Job1<BigQueryLoadJobReference, Integer> {
-  private static final long serialVersionUID = 6405179047095627345L;
+  private static final long serialVersionUID = 2L;
   private static final Logger log = Logger.getLogger(BigQueryLoadFileSetJob.class.getName());
   private final String dataset;
   private final String tableName;

--- a/java/src/main/java/com/google/appengine/tools/mapreduce/bigqueryjobs/BigQueryLoadGoogleCloudStorageFilesJob.java
+++ b/java/src/main/java/com/google/appengine/tools/mapreduce/bigqueryjobs/BigQueryLoadGoogleCloudStorageFilesJob.java
@@ -13,9 +13,9 @@ import com.google.api.services.bigquery.BigqueryRequest;
 import com.google.api.services.bigquery.model.Job;
 import com.google.api.services.bigquery.model.JobReference;
 import com.google.api.services.bigquery.model.TableSchema;
-import com.google.appengine.tools.cloudstorage.GcsFilename;
 import com.google.appengine.tools.cloudstorage.GcsService;
 import com.google.appengine.tools.cloudstorage.GcsServiceFactory;
+import com.google.appengine.tools.mapreduce.GcsFilename;
 import com.google.appengine.tools.mapreduce.GoogleCloudStorageFileSet;
 import com.google.appengine.tools.mapreduce.Marshallers;
 import com.google.appengine.tools.mapreduce.impl.BigQueryConstants;
@@ -115,7 +115,7 @@ public final class BigQueryLoadGoogleCloudStorageFilesJob extends
     long currentBundleSize = 0;
     GcsService GCS_SERVICE = GcsServiceFactory.createGcsService();
     for (GcsFilename file : files) {
-      long fileSize = GCS_SERVICE.getMetadata(file).getLength();
+      long fileSize = GCS_SERVICE.getMetadata(new com.google.appengine.tools.cloudstorage.GcsFilename(file.getBucketName(), file.getObjectName())).getLength();
       if (currentBundleSize + fileSize > bundleSizeLimit) {
         bundles.add(ImmutableSet.copyOf(currentBundle).asList());
         currentBundle = new ArrayList<>();

--- a/java/src/main/java/com/google/appengine/tools/mapreduce/bigqueryjobs/RetryLoadOrCleanupJob.java
+++ b/java/src/main/java/com/google/appengine/tools/mapreduce/bigqueryjobs/RetryLoadOrCleanupJob.java
@@ -3,7 +3,7 @@ package com.google.appengine.tools.mapreduce.bigqueryjobs;
 import com.google.api.services.bigquery.model.ErrorProto;
 import com.google.api.services.bigquery.model.Job;
 import com.google.api.services.bigquery.model.TableSchema;
-import com.google.appengine.tools.cloudstorage.GcsFilename;
+import com.google.appengine.tools.mapreduce.GcsFilename;
 import com.google.appengine.tools.mapreduce.impl.pipeline.DeleteFilesJob;
 import com.google.appengine.tools.mapreduce.impl.util.SerializableValue;
 import com.google.appengine.tools.pipeline.FutureValue;
@@ -24,7 +24,7 @@ import java.util.logging.Logger;
 final class RetryLoadOrCleanupJob extends
     Job2<BigQueryLoadJobReference, BigQueryLoadJobReference, Integer> {
 
-  private static final long serialVersionUID = 6203149802079995465L;
+  private static final long serialVersionUID = 2L;
   private static final Logger log = Logger.getLogger(RetryLoadOrCleanupJob.class.getName());
 
   private final String dataset;

--- a/java/src/main/java/com/google/appengine/tools/mapreduce/impl/GoogleCloudStorageMapOutput.java
+++ b/java/src/main/java/com/google/appengine/tools/mapreduce/impl/GoogleCloudStorageMapOutput.java
@@ -11,6 +11,7 @@ import com.google.appengine.tools.mapreduce.Output;
 import com.google.appengine.tools.mapreduce.OutputWriter;
 import com.google.appengine.tools.mapreduce.Sharder;
 import com.google.appengine.tools.mapreduce.impl.GoogleCloudStorageMapOutputWriter.MapOutputWriter;
+import com.google.appengine.tools.mapreduce.outputs.GoogleCloudStorageFileOutput;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -35,15 +36,17 @@ public class GoogleCloudStorageMapOutput<K, V> extends Output<KeyValue<K, V>, Fi
   private final Marshaller<K> keyMarshaller;
   private final Marshaller<V> valueMarshaller;
   private final Sharder sharder;
+  private final GoogleCloudStorageFileOutput.Options options;
 
   public GoogleCloudStorageMapOutput(String bucket, String mrJobId, Marshaller<K> keyMarshaller,
-      Marshaller<V> valueMarshaller, Sharder sharder) {
+      Marshaller<V> valueMarshaller, Sharder sharder, GoogleCloudStorageFileOutput.Options options) {
     this.bucket = checkNotNull(bucket, "Null bucket");
     this.sharder = checkNotNull(sharder, "Null sharder");
     this.mrJobId = checkNotNull(mrJobId, "Null mrJobId");
     checkArgument(sharder.getNumShards() >= 0);
     this.keyMarshaller = checkNotNull(keyMarshaller, "Null keyMarshaller");
     this.valueMarshaller = checkNotNull(valueMarshaller, "Null valueMarshaller");
+    this.options = options;
   }
 
   @Override
@@ -52,7 +55,7 @@ public class GoogleCloudStorageMapOutput<K, V> extends Output<KeyValue<K, V>, Fi
     for (int i = 0; i < shards; i++) {
       String fileNamePattern = String.format(MAP_OUTPUT_DIR_FORMAT, mrJobId, i);
       OutputWriter<KeyValue<K, V>> writer = new GoogleCloudStorageMapOutputWriter<>(
-          bucket, fileNamePattern, keyMarshaller, valueMarshaller, sharder);
+          bucket, fileNamePattern, keyMarshaller, valueMarshaller, sharder, this.options);
       result.add(writer);
     }
     return result;

--- a/java/src/main/java/com/google/appengine/tools/mapreduce/impl/GoogleCloudStorageMapOutputWriter.java
+++ b/java/src/main/java/com/google/appengine/tools/mapreduce/impl/GoogleCloudStorageMapOutputWriter.java
@@ -1,26 +1,21 @@
 package com.google.appengine.tools.mapreduce.impl;
 
 import static com.google.appengine.tools.mapreduce.impl.MapReduceConstants.DEFAULT_IO_BUFFER_SIZE;
-import static com.google.appengine.tools.mapreduce.impl.MapReduceConstants.GCS_RETRY_PARAMETERS;
 import static com.google.appengine.tools.mapreduce.impl.MapReduceConstants.MAP_OUTPUT_MIME_TYPE;
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import com.google.appengine.tools.cloudstorage.GcsFileOptions;
-import com.google.appengine.tools.cloudstorage.GcsFilename;
-import com.google.appengine.tools.cloudstorage.GcsOutputChannel;
-import com.google.appengine.tools.cloudstorage.GcsService;
-import com.google.appengine.tools.cloudstorage.GcsServiceFactory;
-import com.google.appengine.tools.cloudstorage.GcsServiceOptions;
+
 import com.google.appengine.tools.mapreduce.KeyValue;
 import com.google.appengine.tools.mapreduce.Marshaller;
 import com.google.appengine.tools.mapreduce.OutputWriter;
 import com.google.appengine.tools.mapreduce.Sharder;
-import com.google.appengine.tools.mapreduce.outputs.LevelDbOutputWriter;
-import com.google.appengine.tools.mapreduce.outputs.MarshallingOutputWriter;
-import com.google.appengine.tools.mapreduce.outputs.ShardingOutputWriter;
+import com.google.appengine.tools.mapreduce.outputs.*;
+import com.google.cloud.WriteChannel;
+import com.google.cloud.storage.*;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.AbstractIterator;
-import com.google.common.collect.ImmutableMap;
+import lombok.NonNull;
+import lombok.ToString;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -54,13 +49,16 @@ public class GoogleCloudStorageMapOutputWriter<K, V>
   private final String fileNamePattern;
   private final String bucket;
   private final KeyValueMarshaller<K, V> keyValueMarshaller;
+  private final GoogleCloudStorageFileOutput.Options options;
+
 
   public GoogleCloudStorageMapOutputWriter(String bucket, String fileNamePattern,
-      Marshaller<K> keyMarshaller, Marshaller<V> valueMarshaller, Sharder sharder) {
+      Marshaller<K> keyMarshaller, Marshaller<V> valueMarshaller, Sharder sharder, GoogleCloudStorageFileOutput.Options options) {
     super(keyMarshaller, sharder);
     this.bucket =  checkNotNull(bucket, "Null bucket");
     this.fileNamePattern = checkNotNull(fileNamePattern, "Null fileNamePattern");
     keyValueMarshaller = new KeyValueMarshaller<>(keyMarshaller, valueMarshaller);
+    this.options = options;
   }
 
   @Override
@@ -71,7 +69,7 @@ public class GoogleCloudStorageMapOutputWriter<K, V>
   @Override
   public MapOutputWriter<K, V> createWriter(int sortShard) {
     String namePrefix = String.format(fileNamePattern, sortShard);
-    return new MapOutputWriter<>(new GcsFileOutputWriter(bucket, namePrefix), keyValueMarshaller);
+    return new MapOutputWriter<>(new GcsFileOutputWriter(bucket, namePrefix, this.options), keyValueMarshaller);
   }
 
   @Override
@@ -99,21 +97,16 @@ public class GoogleCloudStorageMapOutputWriter<K, V>
     }
   }
 
+  @ToString
   private static class GcsFileOutputWriter extends OutputWriter<ByteBuffer> {
 
-    private static final long serialVersionUID = 1864188391798776210L;
+    private static final long serialVersionUID = 2L;
     private static final String MAX_COMPONENTS_PER_COMPOSE = "com.google.appengine.tools.mapreduce"
         + ".impl.GoogleCloudStorageMapOutputWriter.MAX_COMPONENTS_PER_COMPOSE";
     private static final String MAX_FILES_PER_COMPOSE = "com.google.appengine.tools.mapreduce.impl"
         + ".GoogleCloudStorageMapOutputWriter.MAX_FILES_PER_COMPOSE";
-    private static final GcsService GCS_SERVICE = GcsServiceFactory.createGcsService(
-        new GcsServiceOptions.Builder()
-        .setRetryParams(GCS_RETRY_PARAMETERS)
-        .setDefaultWriteBufferSize(DEFAULT_IO_BUFFER_SIZE)
-        .setHttpHeaders(ImmutableMap.of("User-Agent", "App Engine MR"))
-        .build());
-    private static final GcsFileOptions FILE_OPTIONS =
-        new GcsFileOptions.Builder().mimeType(MAP_OUTPUT_MIME_TYPE).build();
+    private transient Storage client;
+
     private static final long MEMORY_REQUIRED = MapReduceConstants.DEFAULT_IO_BUFFER_SIZE * 2;
 
 
@@ -124,12 +117,14 @@ public class GoogleCloudStorageMapOutputWriter<K, V>
     private final Set<String> toDelete = new HashSet<>();
     private final Set<String> sliceParts = new LinkedHashSet();
     private final Set<String> compositeParts = new LinkedHashSet<>();
+    @NonNull private final GoogleCloudStorageFileOutput.Options options;
     private String filePrefix;
     private int fileCount;
 
-    private transient GcsOutputChannel channel;
+    private transient WriteChannel channel;
+    private transient Blob sliceBlob;
 
-    public GcsFileOutputWriter(String bucket, String namePrefix) {
+    public GcsFileOutputWriter(String bucket, String namePrefix, GoogleCloudStorageFileOutput.Options options) {
       this.bucket = bucket;
       this.namePrefix = namePrefix;
       int temp = Integer.parseInt(System.getProperty(MAX_COMPONENTS_PER_COMPOSE, "1024"));
@@ -137,14 +132,31 @@ public class GoogleCloudStorageMapOutputWriter<K, V>
       maxComponentsPerCompose = (temp / maxFilesPerCompose) * maxFilesPerCompose;
       Preconditions.checkArgument(maxFilesPerCompose > 0);
       Preconditions.checkArgument(maxComponentsPerCompose > 0);
+      this.options = options;
+    }
+
+    protected Storage getClient() {
+      if (client == null) {
+        //TODO: set retry param (GCS_RETRY_PARAMETERS)
+        //TODO: set User-Agent to "App Engine MR"?
+        if (this.options.getCredentials().isPresent()) {
+          client = StorageOptions.newBuilder()
+            .setCredentials(this.options.getCredentials().get())
+            .setProjectId(this.options.getProjectId())
+            .build().getService();
+        } else {
+          client = StorageOptions.getDefaultInstance().getService();
+        }
+      }
+      return client;
     }
 
     @Override
     public void cleanup() {
       for (String name : toDelete) {
         try {
-          GCS_SERVICE.delete(new GcsFilename(bucket, name));
-        } catch (IOException ex) {
+          getClient().delete(BlobId.of(bucket, name));
+        } catch (StorageException ex) {
           logger.log(Level.WARNING, "Could not cleanup temporary file " + name, ex);
         }
       }
@@ -179,8 +191,11 @@ public class GoogleCloudStorageMapOutputWriter<K, V>
     @Override
     public void write(ByteBuffer bytes) throws IOException {
       if (channel == null) {
-        GcsFilename sliceFile = new GcsFilename(bucket, generateTempFileName());
-        channel = GCS_SERVICE.createOrReplace(sliceFile, FILE_OPTIONS);
+        sliceBlob = getClient().create(
+          BlobInfo.newBuilder(bucket, generateTempFileName())
+            .setContentType(MAP_OUTPUT_MIME_TYPE).build());
+        channel = sliceBlob.writer();
+        channel.setChunkSize(DEFAULT_IO_BUFFER_SIZE);
       }
       while (bytes.hasRemaining()) {
         channel.write(bytes);
@@ -191,7 +206,7 @@ public class GoogleCloudStorageMapOutputWriter<K, V>
     public void endSlice() throws IOException {
       if (channel != null) {
         channel.close();
-        sliceParts.add(channel.getFilename().getObjectName());
+        sliceParts.add(sliceBlob.getBlobId().getName());
         channel = null;
       }
     }
@@ -222,11 +237,11 @@ public class GoogleCloudStorageMapOutputWriter<K, V>
     }
 
     private void compose(Collection<String> source, String target) throws IOException {
-      GcsFilename targetFile = new GcsFilename(bucket, target);
+      BlobInfo targetFile = BlobInfo.newBuilder(bucket, target).build();
       if (source.size() == 1) {
-        GCS_SERVICE.copy(new GcsFilename(bucket, source.iterator().next()), targetFile);
+        getClient().copy(Storage.CopyRequest.of(BlobId.of(bucket, source.iterator().next()), targetFile));
       } else {
-        GCS_SERVICE.compose(source, targetFile);
+        getClient().compose(Storage.ComposeRequest.of(source, targetFile));
       }
       for (String name : source) {
         if (!name.equals(target)) {
@@ -252,16 +267,6 @@ public class GoogleCloudStorageMapOutputWriter<K, V>
           };
         }
       };
-    }
-
-    @Override
-    public String toString() {
-      return getClass().getSimpleName()
-          + " [bucket=" + bucket + ", maxComponentsPerCompose=" + maxComponentsPerCompose
-          + ", maxFilesPerCompose=" + maxFilesPerCompose + ", namePrefix=" + namePrefix
-          + ", filePrefix=" + filePrefix + ", fileCount=" + fileCount
-          + ", toDelete=" + toDelete + ", sliceParts=" + sliceParts
-          + ", compositeParts=" + compositeParts + "]";
     }
   }
 }

--- a/java/src/main/java/com/google/appengine/tools/mapreduce/impl/GoogleCloudStorageMergeInput.java
+++ b/java/src/main/java/com/google/appengine/tools/mapreduce/impl/GoogleCloudStorageMergeInput.java
@@ -2,7 +2,6 @@
 
 package com.google.appengine.tools.mapreduce.impl;
 
-import static com.google.appengine.tools.mapreduce.impl.MapReduceConstants.DEFAULT_IO_BUFFER_SIZE;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.appengine.tools.mapreduce.GoogleCloudStorageFileSet;
@@ -13,9 +12,12 @@ import com.google.appengine.tools.mapreduce.Marshaller;
 import com.google.appengine.tools.mapreduce.Marshallers;
 import com.google.appengine.tools.mapreduce.inputs.ConcatenatingInputReader;
 import com.google.appengine.tools.mapreduce.inputs.GoogleCloudStorageLevelDbInput;
+import com.google.appengine.tools.mapreduce.inputs.GoogleCloudStorageLineInput;
 import com.google.appengine.tools.mapreduce.inputs.PeekingInputReader;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -29,17 +31,16 @@ import java.util.List;
  * (Note the returned sequence will go backwards, see{@link #createReaders()})
  *
  */
+@RequiredArgsConstructor
 public class GoogleCloudStorageMergeInput extends
     Input<KeyValue<ByteBuffer, Iterator<ByteBuffer>>> {
 
-  private static final long serialVersionUID = 3532660814044212575L;
+  private static final long serialVersionUID = 2L;
+
+  @NonNull
   private final FilesByShard filesByShard;
   private final Integer mergeFanin;
-
-  public GoogleCloudStorageMergeInput(FilesByShard files, int mergeFanin) {
-    this.filesByShard = checkNotNull(files, "Null files");
-    this.mergeFanin = mergeFanin;
-  }
+  private final GoogleCloudStorageLineInput.Options options;
 
   /**
    * Creates multiple merging readers for each shard using {@link #createReaderForShard} below.
@@ -84,7 +85,7 @@ public class GoogleCloudStorageMergeInput extends
     ArrayList<PeekingInputReader<KeyValue<ByteBuffer, ? extends Iterable<ByteBuffer>>>> inputFiles =
         new ArrayList<>();
     GoogleCloudStorageLevelDbInput reducerInput =
-        new GoogleCloudStorageLevelDbInput(inputFileSet, DEFAULT_IO_BUFFER_SIZE);
+        new GoogleCloudStorageLevelDbInput(inputFileSet, options);
     for (InputReader<ByteBuffer> in : reducerInput.createReaders()) {
       inputFiles.add(new PeekingInputReader<>(in, marshaller));
     }

--- a/java/src/main/java/com/google/appengine/tools/mapreduce/impl/GoogleCloudStorageMergeOutput.java
+++ b/java/src/main/java/com/google/appengine/tools/mapreduce/impl/GoogleCloudStorageMergeOutput.java
@@ -2,12 +2,7 @@ package com.google.appengine.tools.mapreduce.impl;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import com.google.appengine.tools.cloudstorage.GcsFilename;
-import com.google.appengine.tools.mapreduce.KeyValue;
-import com.google.appengine.tools.mapreduce.Marshaller;
-import com.google.appengine.tools.mapreduce.Marshallers;
-import com.google.appengine.tools.mapreduce.Output;
-import com.google.appengine.tools.mapreduce.OutputWriter;
+import com.google.appengine.tools.mapreduce.*;
 import com.google.appengine.tools.mapreduce.impl.sort.LexicographicalComparator;
 import com.google.appengine.tools.mapreduce.impl.util.SerializableValue;
 import com.google.appengine.tools.mapreduce.outputs.*;

--- a/java/src/main/java/com/google/appengine/tools/mapreduce/impl/GoogleCloudStorageMergeOutput.java
+++ b/java/src/main/java/com/google/appengine/tools/mapreduce/impl/GoogleCloudStorageMergeOutput.java
@@ -7,6 +7,8 @@ import com.google.appengine.tools.mapreduce.impl.sort.LexicographicalComparator;
 import com.google.appengine.tools.mapreduce.impl.util.SerializableValue;
 import com.google.appengine.tools.mapreduce.outputs.*;
 import com.google.common.collect.ImmutableList;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -19,27 +21,19 @@ import java.util.List;
  * sort output).
  *
  */
+@RequiredArgsConstructor
 public class GoogleCloudStorageMergeOutput extends
     Output<KeyValue<ByteBuffer, List<ByteBuffer>>, FilesByShard> {
 
   private static final long serialVersionUID = 2L;
 
+  @NonNull
   private final String bucket;
+  @NonNull
   private final String mrJobId;
+  @NonNull
   private final Integer tier;
   private final GoogleCloudStorageFileOutputWriter.Options options;
-
-  public GoogleCloudStorageMergeOutput(String bucket, String mrJobId, Integer tier) {
-   this(bucket, mrJobId, tier, GoogleCloudStorageFileOutput.BaseOptions.defaults());
-  }
-
-  public GoogleCloudStorageMergeOutput(String bucket, String mrJobId, Integer tier, GoogleCloudStorageFileOutput.Options options) {
-    super();
-    this.tier = checkNotNull(tier, "Null tier");
-    this.bucket = checkNotNull(bucket, "Null bucket");
-    this.mrJobId = checkNotNull(mrJobId, "Null mrJobId");
-    this.options = options;
-  }
 
   private static class OrderSlicingOutputWriter extends
       ItemSegmentingOutputWriter<KeyValue<ByteBuffer, List<ByteBuffer>>> {

--- a/java/src/main/java/com/google/appengine/tools/mapreduce/impl/GoogleCloudStorageMergeOutput.java
+++ b/java/src/main/java/com/google/appengine/tools/mapreduce/impl/GoogleCloudStorageMergeOutput.java
@@ -65,7 +65,7 @@ public class GoogleCloudStorageMergeOutput extends
               new GoogleCloudStorageFileOutputWriter(
                   new GcsFilename(bucket, fileName),
                   MapReduceConstants.REDUCE_INPUT_MIME_TYPE,
-                GoogleCloudStorageFileOutputWriter.BaseOptions.defaults().withSupportSliceRetries(false))),
+                GoogleCloudStorageFileOutput.BaseOptions.defaults().withSupportSliceRetries(false))),
           Marshallers.getKeyValuesMarshaller(identity, identity));
     }
 

--- a/java/src/main/java/com/google/appengine/tools/mapreduce/impl/GoogleCloudStorageMergeOutput.java
+++ b/java/src/main/java/com/google/appengine/tools/mapreduce/impl/GoogleCloudStorageMergeOutput.java
@@ -10,10 +10,7 @@ import com.google.appengine.tools.mapreduce.Output;
 import com.google.appengine.tools.mapreduce.OutputWriter;
 import com.google.appengine.tools.mapreduce.impl.sort.LexicographicalComparator;
 import com.google.appengine.tools.mapreduce.impl.util.SerializableValue;
-import com.google.appengine.tools.mapreduce.outputs.GoogleCloudStorageFileOutputWriter;
-import com.google.appengine.tools.mapreduce.outputs.GoogleCloudStorageLevelDbOutputWriter;
-import com.google.appengine.tools.mapreduce.outputs.ItemSegmentingOutputWriter;
-import com.google.appengine.tools.mapreduce.outputs.MarshallingOutputWriter;
+import com.google.appengine.tools.mapreduce.outputs.*;
 import com.google.common.collect.ImmutableList;
 
 import java.nio.ByteBuffer;
@@ -73,7 +70,7 @@ public class GoogleCloudStorageMergeOutput extends
               new GoogleCloudStorageFileOutputWriter(
                   new GcsFilename(bucket, fileName),
                   MapReduceConstants.REDUCE_INPUT_MIME_TYPE,
-                  false)),
+                GoogleCloudStorageFileOutputWriter.BaseOptions.defaults().withSupportSliceRetries(false))),
           Marshallers.getKeyValuesMarshaller(identity, identity));
     }
 

--- a/java/src/main/java/com/google/appengine/tools/mapreduce/impl/GoogleCloudStorageReduceInput.java
+++ b/java/src/main/java/com/google/appengine/tools/mapreduce/impl/GoogleCloudStorageReduceInput.java
@@ -12,8 +12,11 @@ import com.google.appengine.tools.mapreduce.KeyValue;
 import com.google.appengine.tools.mapreduce.Marshaller;
 import com.google.appengine.tools.mapreduce.Marshallers;
 import com.google.appengine.tools.mapreduce.inputs.GoogleCloudStorageLevelDbInput;
+import com.google.appengine.tools.mapreduce.inputs.GoogleCloudStorageLineInput;
 import com.google.appengine.tools.mapreduce.inputs.PeekingInputReader;
 import com.google.common.collect.ImmutableList;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -31,19 +34,18 @@ import java.util.List;
  * @param <K> type of intermediate keys
  * @param <V> type of intermediate values
  */
+@RequiredArgsConstructor
 public class GoogleCloudStorageReduceInput<K, V> extends Input<KeyValue<K, Iterator<V>>> {
 
-  private static final long serialVersionUID = 8877197357362096382L;
-  private final Marshaller<K> keyMarshaller;
-  private final Marshaller<V> valueMarshaller;
-  private final FilesByShard filesByShard;
+  private static final long serialVersionUID = 2L;
 
-  public GoogleCloudStorageReduceInput(FilesByShard files,
-      Marshaller<K> keyMarshaller, Marshaller<V> valueMarshaller) {
-    this.filesByShard = checkNotNull(files, "Null files");
-    this.keyMarshaller = checkNotNull(keyMarshaller, "Null keyMarshaller");
-    this.valueMarshaller = checkNotNull(valueMarshaller, "Null valueMarshaller");
-  }
+  @NonNull
+  private final FilesByShard filesByShard;
+  @NonNull
+  private final Marshaller<K> keyMarshaller;
+  @NonNull
+  private final Marshaller<V> valueMarshaller;
+  private final GoogleCloudStorageLineInput.Options options;
 
   @Override
   public List<? extends InputReader<KeyValue<K, Iterator<V>>>> createReaders() {
@@ -74,7 +76,7 @@ public class GoogleCloudStorageReduceInput<K, V> extends Input<KeyValue<K, Itera
     ArrayList<PeekingInputReader<KeyValue<ByteBuffer, ? extends Iterable<V>>>> inputFiles =
         new ArrayList<>();
     GoogleCloudStorageLevelDbInput reducerInput =
-        new GoogleCloudStorageLevelDbInput(reducerInputFileSet, DEFAULT_IO_BUFFER_SIZE);
+        new GoogleCloudStorageLevelDbInput(reducerInputFileSet, options);
     for (InputReader<ByteBuffer> in : reducerInput.createReaders()) {
       inputFiles.add(new PeekingInputReader<>(in, marshaller));
     }

--- a/java/src/main/java/com/google/appengine/tools/mapreduce/impl/GoogleCloudStorageSortInput.java
+++ b/java/src/main/java/com/google/appengine/tools/mapreduce/impl/GoogleCloudStorageSortInput.java
@@ -2,9 +2,6 @@
 
 package com.google.appengine.tools.mapreduce.impl;
 
-import static com.google.appengine.tools.mapreduce.impl.MapReduceConstants.DEFAULT_IO_BUFFER_SIZE;
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import com.google.appengine.tools.mapreduce.*;
 import com.google.appengine.tools.mapreduce.inputs.*;
 import com.google.common.collect.ImmutableList;

--- a/java/src/main/java/com/google/appengine/tools/mapreduce/impl/GoogleCloudStorageSortInput.java
+++ b/java/src/main/java/com/google/appengine/tools/mapreduce/impl/GoogleCloudStorageSortInput.java
@@ -5,12 +5,7 @@ package com.google.appengine.tools.mapreduce.impl;
 import static com.google.appengine.tools.mapreduce.impl.MapReduceConstants.DEFAULT_IO_BUFFER_SIZE;
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import com.google.appengine.tools.cloudstorage.GcsFilename;
-import com.google.appengine.tools.mapreduce.Input;
-import com.google.appengine.tools.mapreduce.InputReader;
-import com.google.appengine.tools.mapreduce.KeyValue;
-import com.google.appengine.tools.mapreduce.Marshaller;
-import com.google.appengine.tools.mapreduce.Marshallers;
+import com.google.appengine.tools.mapreduce.*;
 import com.google.appengine.tools.mapreduce.inputs.ConcatenatingInputReader;
 import com.google.appengine.tools.mapreduce.inputs.ForwardingInputReader;
 import com.google.appengine.tools.mapreduce.inputs.GoogleCloudStorageLevelDbInputReader;

--- a/java/src/main/java/com/google/appengine/tools/mapreduce/impl/GoogleCloudStorageSortOutput.java
+++ b/java/src/main/java/com/google/appengine/tools/mapreduce/impl/GoogleCloudStorageSortOutput.java
@@ -23,32 +23,36 @@ import java.util.Map.Entry;
 public class GoogleCloudStorageSortOutput extends
     Output<KeyValue<ByteBuffer, List<ByteBuffer>>, FilesByShard> {
 
-  private static final long serialVersionUID = 8332978108336443982L;
+  private static final long serialVersionUID = 2L;
 
   private final String bucket;
   private final String mrJobId;
   private final Sharder sharder;
+  private final GoogleCloudStorageFileOutputWriter.Options options;
 
   private static class ShardingOutputWriterImpl extends
       ShardingOutputWriter<ByteBuffer, List<ByteBuffer>, SlicingOutputWriterImpl> {
 
-    private static final long serialVersionUID = -8890301705089321212L;
+    private static final long serialVersionUID = 2L;
+
     private final String mrJobId;
     private final int shard;
     private final String bucket;
+    private final GoogleCloudStorageFileOutputWriter.Options options;
 
-    ShardingOutputWriterImpl(String mrJobId, String bucket, int shard, Sharder sharder) {
+    ShardingOutputWriterImpl(String mrJobId, String bucket, int shard, Sharder sharder, GoogleCloudStorageFileOutputWriter.Options options) {
       super(Marshallers.getByteBufferMarshaller(), sharder);
       this.mrJobId = mrJobId;
       this.bucket = bucket;
       this.shard = shard;
+      this.options = options;
     }
 
     @Override
     public SlicingOutputWriterImpl createWriter(int number) {
       String formatStringForShard =
           String.format(MapReduceConstants.SORT_OUTPUT_DIR_FORMAT, mrJobId, shard, number);
-      return new SlicingOutputWriterImpl(bucket, formatStringForShard);
+      return new SlicingOutputWriterImpl(bucket, formatStringForShard, options);
     }
 
     @Override
@@ -72,15 +76,17 @@ public class GoogleCloudStorageSortOutput extends
     private final String bucket;
     private final String fileNamePattern;
     private final List<String> fileNames;
+    private final GoogleCloudStorageFileOutputWriter.Options options;
 
     /**
      * @param fileNamePattern a Java format string {@link java.util.Formatter} containing one int
      *        argument for the slice number.
      */
-    public SlicingOutputWriterImpl(String bucket, String fileNamePattern) {
+    SlicingOutputWriterImpl(String bucket, String fileNamePattern, GoogleCloudStorageFileOutputWriter.Options options) {
       this.bucket = checkNotNull(bucket, "Null bucket");
       this.fileNamePattern = checkNotNull(fileNamePattern, "Null fileNamePattern");
       this.fileNames = new ArrayList<>();
+      this.options = options;
     }
 
     @Override
@@ -109,10 +115,12 @@ public class GoogleCloudStorageSortOutput extends
     }
   }
 
-  public GoogleCloudStorageSortOutput(String bucket, String mrJobId, Sharder sharder) {
+  public GoogleCloudStorageSortOutput(String bucket, String mrJobId, Sharder sharder, GoogleCloudStorageFileOutput.Options options) {
+    super();
     this.bucket = checkNotNull(bucket, "Null bucket");
     this.mrJobId = checkNotNull(mrJobId, "Null mrJobId");
     this.sharder = checkNotNull(sharder, "Null sharder");
+    this.options = options;
   }
 
   @Override
@@ -121,7 +129,7 @@ public class GoogleCloudStorageSortOutput extends
     List<OutputWriter<KeyValue<ByteBuffer, List<ByteBuffer>>>> result = new ArrayList<>(shards);
     for (int i = 0; i < shards; i++) {
       OutputWriter<KeyValue<ByteBuffer, List<ByteBuffer>>> shardingWriter =
-          new ShardingOutputWriterImpl(mrJobId, bucket, i, sharder);
+          new ShardingOutputWriterImpl(mrJobId, bucket, i, sharder, options);
       result.add(shardingWriter);
     }
     return result;

--- a/java/src/main/java/com/google/appengine/tools/mapreduce/impl/GoogleCloudStorageSortOutput.java
+++ b/java/src/main/java/com/google/appengine/tools/mapreduce/impl/GoogleCloudStorageSortOutput.java
@@ -101,7 +101,7 @@ public class GoogleCloudStorageSortOutput extends
       // unneeded as the file is being finalized.
       return new MarshallingOutputWriter<>(
           new LevelDbOutputWriter(new GoogleCloudStorageFileOutputWriter(
-              new GcsFilename(bucket, fileName), MapReduceConstants.REDUCE_INPUT_MIME_TYPE, GoogleCloudStorageFileOutput.BaseOptions.defaults().withSupportSliceRetries(false))),
+              new GcsFilename(bucket, fileName), MapReduceConstants.REDUCE_INPUT_MIME_TYPE, options.withSupportSliceRetries(false))),
           Marshallers.getKeyValuesMarshaller(identity, identity));
     }
 

--- a/java/src/main/java/com/google/appengine/tools/mapreduce/impl/GoogleCloudStorageSortOutput.java
+++ b/java/src/main/java/com/google/appengine/tools/mapreduce/impl/GoogleCloudStorageSortOutput.java
@@ -3,13 +3,7 @@ package com.google.appengine.tools.mapreduce.impl;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import com.google.appengine.tools.cloudstorage.GcsFilename;
-import com.google.appengine.tools.mapreduce.KeyValue;
-import com.google.appengine.tools.mapreduce.Marshaller;
-import com.google.appengine.tools.mapreduce.Marshallers;
-import com.google.appengine.tools.mapreduce.Output;
-import com.google.appengine.tools.mapreduce.OutputWriter;
-import com.google.appengine.tools.mapreduce.Sharder;
+import com.google.appengine.tools.mapreduce.*;
 import com.google.appengine.tools.mapreduce.outputs.*;
 
 import java.nio.ByteBuffer;

--- a/java/src/main/java/com/google/appengine/tools/mapreduce/impl/GoogleCloudStorageSortOutput.java
+++ b/java/src/main/java/com/google/appengine/tools/mapreduce/impl/GoogleCloudStorageSortOutput.java
@@ -95,7 +95,7 @@ public class GoogleCloudStorageSortOutput extends
       // unneeded as the file is being finalized.
       return new MarshallingOutputWriter<>(
           new LevelDbOutputWriter(new GoogleCloudStorageFileOutputWriter(
-              new GcsFilename(bucket, fileName), MapReduceConstants.REDUCE_INPUT_MIME_TYPE, GoogleCloudStorageFileOutputWriter.BaseOptions.defaults().withSupportSliceRetries(false))),
+              new GcsFilename(bucket, fileName), MapReduceConstants.REDUCE_INPUT_MIME_TYPE, GoogleCloudStorageFileOutput.BaseOptions.defaults().withSupportSliceRetries(false))),
           Marshallers.getKeyValuesMarshaller(identity, identity));
     }
 

--- a/java/src/main/java/com/google/appengine/tools/mapreduce/impl/GoogleCloudStorageSortOutput.java
+++ b/java/src/main/java/com/google/appengine/tools/mapreduce/impl/GoogleCloudStorageSortOutput.java
@@ -10,11 +10,7 @@ import com.google.appengine.tools.mapreduce.Marshallers;
 import com.google.appengine.tools.mapreduce.Output;
 import com.google.appengine.tools.mapreduce.OutputWriter;
 import com.google.appengine.tools.mapreduce.Sharder;
-import com.google.appengine.tools.mapreduce.outputs.GoogleCloudStorageFileOutputWriter;
-import com.google.appengine.tools.mapreduce.outputs.LevelDbOutputWriter;
-import com.google.appengine.tools.mapreduce.outputs.MarshallingOutputWriter;
-import com.google.appengine.tools.mapreduce.outputs.ShardingOutputWriter;
-import com.google.appengine.tools.mapreduce.outputs.SliceSegmentingOutputWriter;
+import com.google.appengine.tools.mapreduce.outputs.*;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -105,7 +101,7 @@ public class GoogleCloudStorageSortOutput extends
       // unneeded as the file is being finalized.
       return new MarshallingOutputWriter<>(
           new LevelDbOutputWriter(new GoogleCloudStorageFileOutputWriter(
-              new GcsFilename(bucket, fileName), MapReduceConstants.REDUCE_INPUT_MIME_TYPE, false)),
+              new GcsFilename(bucket, fileName), MapReduceConstants.REDUCE_INPUT_MIME_TYPE, GoogleCloudStorageFileOutputWriter.BaseOptions.defaults().withSupportSliceRetries(false))),
           Marshallers.getKeyValuesMarshaller(identity, identity));
     }
 

--- a/java/src/main/java/com/google/appengine/tools/mapreduce/impl/pipeline/CleanupPipelineJob.java
+++ b/java/src/main/java/com/google/appengine/tools/mapreduce/impl/pipeline/CleanupPipelineJob.java
@@ -1,13 +1,7 @@
 package com.google.appengine.tools.mapreduce.impl.pipeline;
 
-import com.google.appengine.tools.cloudstorage.GcsFilename;
-import com.google.appengine.tools.pipeline.FutureValue;
-import com.google.appengine.tools.pipeline.Job1;
-import com.google.appengine.tools.pipeline.JobSetting;
-import com.google.appengine.tools.pipeline.Jobs;
-import com.google.appengine.tools.pipeline.PipelineService;
-import com.google.appengine.tools.pipeline.PipelineServiceFactory;
-import com.google.appengine.tools.pipeline.Value;
+import com.google.appengine.tools.mapreduce.GcsFilename;
+import com.google.appengine.tools.pipeline.*;
 import com.google.common.collect.Lists;
 
 import java.util.ArrayList;

--- a/java/src/main/java/com/google/appengine/tools/mapreduce/impl/pipeline/DeleteFilesJob.java
+++ b/java/src/main/java/com/google/appengine/tools/mapreduce/impl/pipeline/DeleteFilesJob.java
@@ -2,10 +2,10 @@ package com.google.appengine.tools.mapreduce.impl.pipeline;
 
 import static com.google.appengine.tools.mapreduce.impl.MapReduceConstants.GCS_RETRY_PARAMETERS;
 
-import com.google.appengine.tools.cloudstorage.GcsFilename;
 import com.google.appengine.tools.cloudstorage.GcsService;
 import com.google.appengine.tools.cloudstorage.GcsServiceFactory;
 import com.google.appengine.tools.cloudstorage.RetriesExhaustedException;
+import com.google.appengine.tools.mapreduce.GcsFilename;
 import com.google.appengine.tools.pipeline.Job1;
 import com.google.appengine.tools.pipeline.Value;
 
@@ -30,7 +30,7 @@ public class DeleteFilesJob extends Job1<Void, List<GcsFilename>> {
   public Value<Void> run(List<GcsFilename> files) throws Exception {
     for (GcsFilename file : files) {
       try {
-        gcs.delete(file);
+        gcs.delete(new com.google.appengine.tools.cloudstorage.GcsFilename(file.getBucketName(), file.getObjectName()));
       } catch (RetriesExhaustedException | IOException e) {
         log.log(Level.WARNING, "Failed to cleanup file: " + file, e);
       }

--- a/java/src/main/java/com/google/appengine/tools/mapreduce/impl/shardedjob/ShardedJobSettings.java
+++ b/java/src/main/java/com/google/appengine/tools/mapreduce/impl/shardedjob/ShardedJobSettings.java
@@ -31,6 +31,8 @@ public final class ShardedJobSettings implements Serializable {
 
   public static final int DEFAULT_SLICE_TIMEOUT_MILLIS = 11 * 60000;
 
+  //q: does this need to get bucketName / credentials?
+
   /*Nullable*/ private final String backend;
   /*Nullable*/ private final String module;
   /*Nullable*/ private final String version;

--- a/java/src/main/java/com/google/appengine/tools/mapreduce/impl/shardedjob/ShardedJobSettings.java
+++ b/java/src/main/java/com/google/appengine/tools/mapreduce/impl/shardedjob/ShardedJobSettings.java
@@ -6,6 +6,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.appengine.api.backends.BackendServiceFactory;
 import com.google.appengine.api.modules.ModulesServiceFactory;
+import lombok.Getter;
+import lombok.ToString;
 
 import static com.google.appengine.tools.mapreduce.MapSettings.DEFAULT_BASE_URL;
 import static com.google.appengine.tools.mapreduce.MapSettings.WORKER_PATH;
@@ -21,6 +23,8 @@ import java.io.Serializable;
  *
  * @author ohler@google.com (Christian Ohler)
  */
+@Getter
+@ToString
 public final class ShardedJobSettings implements Serializable {
 
   private static final long serialVersionUID = 286995366653078363L;
@@ -156,60 +160,6 @@ public final class ShardedJobSettings implements Serializable {
     return mrStatusUrl;
   }
 
-  /*Nullable*/ public String getPipelineStatusUrl() {
-    return pipelineStatusUrl;
-  }
 
-  /*Nullable*/ public String getBackend() {
-    return backend;
-  }
 
-  public String getModule() {
-    return module;
-  }
-
-  public String getVersion() {
-    return version;
-  }
-
-  public String getControllerPath() {
-    return controllerPath;
-  }
-
-  public String getWorkerPath() {
-    return workerPath;
-  }
-
-  public String getQueueName() {
-    return queueName;
-  }
-
-  public int getMaxShardRetries() {
-    return maxShardRetries;
-  }
-
-  public int getMaxSliceRetries() {
-    return maxSliceRetries;
-  }
-
-  public int getSliceTimeoutMillis() {
-    return sliceTimeoutMillis;
-  }
-
-  @Override
-  public String toString() {
-    return getClass().getSimpleName() + "("
-        + backend + ", "
-        + mrStatusUrl + ", "
-        + pipelineStatusUrl + ", "
-        + controllerPath + ", "
-        + workerPath + ", "
-        + queueName + ", "
-        + maxShardRetries + ", "
-        + maxSliceRetries + ", "
-        + module + ", "
-        + version + ", "
-        + target + ", "
-        + sliceTimeoutMillis + ")";
-  }
 }

--- a/java/src/main/java/com/google/appengine/tools/mapreduce/inputs/GoogleCloudStorageLevelDbInput.java
+++ b/java/src/main/java/com/google/appengine/tools/mapreduce/inputs/GoogleCloudStorageLevelDbInput.java
@@ -1,13 +1,11 @@
 package com.google.appengine.tools.mapreduce.inputs;
 
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
-
-import com.google.appengine.tools.cloudstorage.GcsFilename;
+import com.google.appengine.tools.mapreduce.GcsFilename;
 import com.google.appengine.tools.mapreduce.GoogleCloudStorageFileSet;
 import com.google.appengine.tools.mapreduce.Input;
 import com.google.appengine.tools.mapreduce.InputReader;
 import com.google.appengine.tools.mapreduce.impl.MapReduceConstants;
+import lombok.*;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -19,14 +17,19 @@ import java.util.List;
  * Google Cloud Storage.
  *
  */
+@RequiredArgsConstructor
 public final class GoogleCloudStorageLevelDbInput extends Input<ByteBuffer> {
 
-  private static final long serialVersionUID = -5135725511174133847L;
+  private static final long serialVersionUID = 2L;
+
+  @NonNull
   private final GoogleCloudStorageFileSet files;
-  private final int bufferSize;
+  @NonNull
+  private final GoogleCloudStorageLineInput.Options options;
+
 
   public GoogleCloudStorageLevelDbInput(GoogleCloudStorageFileSet files) {
-    this(files, MapReduceConstants.DEFAULT_IO_BUFFER_SIZE);
+    this(files, GoogleCloudStorageLineInput.BaseOptions.defaults().withBufferSize(MapReduceConstants.DEFAULT_IO_BUFFER_SIZE));
   }
 
   /**
@@ -34,9 +37,7 @@ public final class GoogleCloudStorageLevelDbInput extends Input<ByteBuffer> {
    * @param bufferSize The size of the buffer used for each file.
    */
   public GoogleCloudStorageLevelDbInput(GoogleCloudStorageFileSet files, int bufferSize) {
-    this.files = checkNotNull(files, "Null files");
-    this.bufferSize = bufferSize;
-    checkArgument(bufferSize > 0, "Buffersize must be > 0");
+    this(files, GoogleCloudStorageLineInput.BaseOptions.defaults().withBufferSize(bufferSize));
   }
 
 
@@ -44,7 +45,7 @@ public final class GoogleCloudStorageLevelDbInput extends Input<ByteBuffer> {
   public List<InputReader<ByteBuffer>> createReaders() {
     List<InputReader<ByteBuffer>> result = new ArrayList<>();
     for (GcsFilename file : files.getFiles()) {
-      result.add(new GoogleCloudStorageLevelDbInputReader(file, bufferSize));
+      result.add(new GoogleCloudStorageLevelDbInputReader(file, options));
     }
     return result;
   }

--- a/java/src/main/java/com/google/appengine/tools/mapreduce/inputs/GoogleCloudStorageLevelDbInputReader.java
+++ b/java/src/main/java/com/google/appengine/tools/mapreduce/inputs/GoogleCloudStorageLevelDbInputReader.java
@@ -31,7 +31,6 @@ public final class GoogleCloudStorageLevelDbInputReader extends LevelDbInputRead
    * @param bufferSize The buffersize to be used by the Gcs prefetching read channel.
    */
   public GoogleCloudStorageLevelDbInputReader(GcsFilename file, int bufferSize) {
-
     this(file, GoogleCloudStorageLineInput.BaseOptions.defaults().withBufferSize(bufferSize));
   }
 

--- a/java/src/main/java/com/google/appengine/tools/mapreduce/inputs/GoogleCloudStorageLevelDbInputReader.java
+++ b/java/src/main/java/com/google/appengine/tools/mapreduce/inputs/GoogleCloudStorageLevelDbInputReader.java
@@ -1,60 +1,68 @@
 package com.google.appengine.tools.mapreduce.inputs;
 
-import static com.google.appengine.tools.mapreduce.impl.MapReduceConstants.GCS_RETRY_PARAMETERS;
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
-
-import com.google.appengine.tools.cloudstorage.GcsFileMetadata;
-import com.google.appengine.tools.cloudstorage.GcsFilename;
-import com.google.appengine.tools.cloudstorage.GcsService;
-import com.google.appengine.tools.cloudstorage.GcsServiceFactory;
-import com.google.appengine.tools.cloudstorage.GcsServiceOptions;
+import com.google.appengine.tools.mapreduce.GcsFilename;
 import com.google.appengine.tools.mapreduce.impl.util.LevelDbConstants;
-import com.google.common.collect.ImmutableMap;
+import com.google.cloud.ReadChannel;
+import com.google.cloud.storage.*;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
 
-import java.io.IOException;
 import java.nio.channels.ReadableByteChannel;
 
+@RequiredArgsConstructor
 /**
  * A simple wrapper of LevelDb wrapper for GCS to provide getProgress() and do lazy initialization.
  */
 public final class GoogleCloudStorageLevelDbInputReader extends LevelDbInputReader {
 
-  private static final GcsService gcsService = GcsServiceFactory.createGcsService(
-      new GcsServiceOptions.Builder()
-          .setRetryParams(GCS_RETRY_PARAMETERS)
-          .setHttpHeaders(ImmutableMap.of("User-Agent", "App Engine MR"))
-          .build());
+  private static final long serialVersionUID = 2L;
 
-  private static final long serialVersionUID = 1014960525070958327L;
-
+  @NonNull
   private final GcsFilename file;
-  private final int bufferSize;
+  @NonNull
+  private final GoogleCloudStorageLineInputReader.Options options;
   private double length = -1;
+
+  private transient Storage client;
+
 
   /**
    * @param file File to be read.
    * @param bufferSize The buffersize to be used by the Gcs prefetching read channel.
    */
   public GoogleCloudStorageLevelDbInputReader(GcsFilename file, int bufferSize) {
-    this.file = checkNotNull(file, "Null file");
-    this.bufferSize = bufferSize;
-    checkArgument(bufferSize > 0, "Buffersize must be > 0");
+
+    this(file, GoogleCloudStorageLineInput.BaseOptions.defaults().withBufferSize(bufferSize));
+  }
+
+  protected Storage getClient() {
+    if (client == null) {
+      //TODO: set retry param (GCS_RETRY_PARAMETERS)
+      //TODO: set User-Agent to "App Engine MR"?
+      if (this.options.getCredentials().isPresent()) {
+        client = StorageOptions.newBuilder()
+          .setCredentials(this.options.getCredentials().get())
+          .build().getService();
+      } else {
+        client = StorageOptions.getDefaultInstance().getService();
+      }
+    }
+    return client;
   }
 
   @Override
   public Double getProgress() {
     if (length == -1) {
-      GcsFileMetadata metadata = null;
+      Blob blob = null;
       try {
-        metadata = gcsService.getMetadata(file);
-      } catch (IOException e) {
+        blob = getClient().get(file.asBlobId());
+      } catch (StorageException e) {
         // It is just an estimate so it's probably not worth throwing.
       }
-      if (metadata == null) {
+      if (blob == null) {
         return null;
       }
-      length = metadata.getLength();
+      length = blob.getSize();
     }
     if (length == 0f) {
       return null;
@@ -65,11 +73,13 @@ public final class GoogleCloudStorageLevelDbInputReader extends LevelDbInputRead
   @Override
   public ReadableByteChannel createReadableByteChannel() {
     length = -1;
-    return gcsService.openPrefetchingReadChannel(file, 0, bufferSize);
+    ReadChannel reader = getClient().reader(file.asBlobId());
+    reader.setChunkSize(options.getBufferSize());
+    return reader;
   }
 
   @Override
   public long estimateMemoryRequirement() {
-    return LevelDbConstants.BLOCK_SIZE + bufferSize * 2; // Double buffered
+    return LevelDbConstants.BLOCK_SIZE + options.getBufferSize() * 2; // Double buffered
   }
 }

--- a/java/src/main/java/com/google/appengine/tools/mapreduce/inputs/GoogleCloudStorageLineInput.java
+++ b/java/src/main/java/com/google/appengine/tools/mapreduce/inputs/GoogleCloudStorageLineInput.java
@@ -75,7 +75,7 @@ public class GoogleCloudStorageLineInput extends Input<byte[]> {
     for (int i = 1; i < shardCount; i++) {
       long endOffset = (i * blobSize) / shardCount;
       result.add(new GoogleCloudStorageLineInputReader(file, startOffset, endOffset, separator,
-          bufferSize));
+          GoogleCloudStorageLineInputReader.BaseOptions.defaults()));
       startOffset = endOffset;
     }
     result.add(new GoogleCloudStorageLineInputReader(file, startOffset, blobSize, separator));

--- a/java/src/main/java/com/google/appengine/tools/mapreduce/inputs/GoogleCloudStorageLineInput.java
+++ b/java/src/main/java/com/google/appengine/tools/mapreduce/inputs/GoogleCloudStorageLineInput.java
@@ -26,15 +26,16 @@ public class GoogleCloudStorageLineInput extends Input<byte[]> {
 
   private static final long MIN_SHARD_SIZE = 1024L;
 
-  private static final long serialVersionUID = 5501931160319682453L;
-
-
+  private static final long serialVersionUID = 2L;
 
   private final GcsFilename file;
   private final byte separator;
   private final int shardCount;
   private final Options options;
 
+  /**
+   * Options - everything the reader needs, plus anything needed by input at top-level
+   */
   public interface Options extends GoogleCloudStorageLineInputReader.Options {
 
     int DEFAULT_BUFFER_SIZE = 1024 * 1024;

--- a/java/src/main/java/com/google/appengine/tools/mapreduce/inputs/GoogleCloudStorageLineInput.java
+++ b/java/src/main/java/com/google/appengine/tools/mapreduce/inputs/GoogleCloudStorageLineInput.java
@@ -13,6 +13,7 @@ import com.google.cloud.storage.StorageOptions;
 import com.google.common.base.Preconditions;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import lombok.With;
 
 import java.util.ArrayList;
@@ -22,6 +23,7 @@ import java.util.Optional;
 /**
  * CloudStorageLineInput shards files in Cloud Storage on separator boundaries.
  */
+@RequiredArgsConstructor
 public class GoogleCloudStorageLineInput extends Input<byte[]> {
 
   private static final long MIN_SHARD_SIZE = 1024L;

--- a/java/src/main/java/com/google/appengine/tools/mapreduce/inputs/GoogleCloudStorageLineInputReader.java
+++ b/java/src/main/java/com/google/appengine/tools/mapreduce/inputs/GoogleCloudStorageLineInputReader.java
@@ -1,59 +1,105 @@
 package com.google.appengine.tools.mapreduce.inputs;
 
-import static com.google.appengine.tools.mapreduce.impl.MapReduceConstants.GCS_RETRY_PARAMETERS;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.appengine.tools.cloudstorage.GcsFilename;
-import com.google.appengine.tools.cloudstorage.GcsService;
-import com.google.appengine.tools.cloudstorage.GcsServiceFactory;
-import com.google.appengine.tools.cloudstorage.GcsServiceOptions;
 import com.google.appengine.tools.mapreduce.InputReader;
+import com.google.appengine.tools.mapreduce.outputs.GoogleCloudStorageFileOutputWriter;
+import com.google.auth.Credentials;
+import com.google.cloud.ReadChannel;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageOptions;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableMap;
+import lombok.Builder;
+import lombok.Getter;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.Serializable;
 import java.nio.channels.Channels;
 import java.util.NoSuchElementException;
+import java.util.Optional;
 
 /**
  * CloudStorageLineInputReader reads files from Cloud Storage one line at a time.
  *
  */
 class GoogleCloudStorageLineInputReader extends InputReader<byte[]> {
-  private static final long serialVersionUID = -762091129798691745L;
-
-  private static final GcsService GCS_SERVICE = GcsServiceFactory.createGcsService(
-      new GcsServiceOptions.Builder()
-          .setRetryParams(GCS_RETRY_PARAMETERS)
-          .setHttpHeaders(ImmutableMap.of("User-Agent", "App Engine MR"))
-          .build());
+  private static final long serialVersionUID = 2L;
 
   private static final int DEFAULT_BUFFER_SIZE = 1024 * 1024;
+
+
+  public interface Options extends Serializable {
+
+    Integer getBufferSize();
+
+    Optional<Credentials> getCredentials();
+
+  }
+
+  @Builder
+  public static class BaseOptions implements Options {
+
+    @Getter @Builder.Default
+    Integer bufferSize = DEFAULT_BUFFER_SIZE;
+
+    private Credentials credentials;
+
+    public static BaseOptions defaults() {
+      return GoogleCloudStorageLineInputReader.BaseOptions.builder().build();
+    }
+
+    public Optional<Credentials> getCredentials() {
+      return Optional.ofNullable(this.credentials);
+    }
+
+  }
+
 
   @VisibleForTesting final long startOffset;
   @VisibleForTesting final long endOffset;
   private final GcsFilename file;
   private long offset;
-  private final int bufferSize;
-  private transient LineInputStream in;
   private final byte separator;
+  private Options options;
+
+  private transient LineInputStream in;
+  private transient Storage client;
+
 
   GoogleCloudStorageLineInputReader(GcsFilename file, long startOffset, long endOffset,
       byte separator) {
-    this(file, startOffset, endOffset, separator, DEFAULT_BUFFER_SIZE);
+    this(file, startOffset, endOffset, separator, (Options) BaseOptions.defaults());
   }
 
   GoogleCloudStorageLineInputReader(GcsFilename file, long startOffset, long endOffset,
-      byte separator, int bufferSize) {
+      byte separator, Options options) {
     this.separator = separator;
     this.file = checkNotNull(file, "Null file");
     Preconditions.checkArgument(endOffset >= startOffset);
     this.startOffset = startOffset;
     this.endOffset = endOffset;
-    this.bufferSize = (bufferSize > 0) ? bufferSize : DEFAULT_BUFFER_SIZE;
+    Preconditions.checkArgument(options.getBufferSize() > 0, "buffersize must be > 0");
+    this.options = options;
   }
+
+  protected Storage getClient() {
+    if (client == null) {
+      //TODO: set retry param (GCS_RETRY_PARAMETERS)
+      //TODO: set User-Agent to "App Engine MR"?
+      if (this.options.getCredentials().isPresent()) {
+        client = StorageOptions.newBuilder()
+          .setCredentials(this.options.getCredentials().get())
+          .build().getService();
+      } else {
+        client = StorageOptions.getDefaultInstance().getService();
+      }
+    }
+    return client;
+  }
+
 
   @Override
   public Double getProgress() {
@@ -72,11 +118,15 @@ class GoogleCloudStorageLineInputReader extends InputReader<byte[]> {
   }
 
   @Override
-  public void beginSlice() {
+  public void beginSlice() throws IOException {
     Preconditions.checkState(in == null, "%s: Already initialized: %s", this, in);
+
+    ReadChannel reader = getClient().reader(file.getBucketName(), file.getObjectName());
+    reader.setChunkSize(options.getBufferSize());
+    reader.seek(startOffset + offset);
+
     @SuppressWarnings("resource")
-    InputStream inputStream = Channels.newInputStream(
-        GCS_SERVICE.openPrefetchingReadChannel(file, startOffset + offset, bufferSize));
+    InputStream inputStream = Channels.newInputStream(reader);
     in = new LineInputStream(inputStream, endOffset - startOffset - offset, separator);
     skipRecordReadByPreviousShard();
   }
@@ -109,6 +159,6 @@ class GoogleCloudStorageLineInputReader extends InputReader<byte[]> {
 
   @Override
   public long estimateMemoryRequirement() {
-    return bufferSize * 2; // Double buffered
+    return options.getBufferSize() * 2; // Double buffered
   }
 }

--- a/java/src/main/java/com/google/appengine/tools/mapreduce/inputs/LevelDbInputReader.java
+++ b/java/src/main/java/com/google/appengine/tools/mapreduce/inputs/LevelDbInputReader.java
@@ -66,7 +66,7 @@ public abstract class LevelDbInputReader extends InputReader<ByteBuffer> {
   /**
    * @return A Serializable ReadableByteChannel from which data may be read.
    */
-  public abstract ReadableByteChannel createReadableByteChannel();
+  public abstract ReadableByteChannel createReadableByteChannel() throws IOException;
 
   private int read(ByteBuffer result) throws IOException {
     int totalRead = 0;
@@ -90,7 +90,7 @@ public abstract class LevelDbInputReader extends InputReader<ByteBuffer> {
   }
 
   @Override
-  public void beginShard() {
+  public void beginShard() throws IOException {
     offset = 0;
     bytesRead = 0;
     in = createReadableByteChannel();

--- a/java/src/main/java/com/google/appengine/tools/mapreduce/inputs/LevelDbInputReader.java
+++ b/java/src/main/java/com/google/appengine/tools/mapreduce/inputs/LevelDbInputReader.java
@@ -7,9 +7,12 @@ import com.google.appengine.tools.mapreduce.InputReader;
 import com.google.appengine.tools.mapreduce.impl.util.Crc32c;
 import com.google.appengine.tools.mapreduce.impl.util.LevelDbConstants;
 import com.google.appengine.tools.mapreduce.impl.util.LevelDbConstants.RecordType;
+import com.google.cloud.Restorable;
+import com.google.cloud.RestorableState;
 import com.google.common.annotations.VisibleForTesting;
 
 import java.io.IOException;
+import java.io.Serializable;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.channels.ReadableByteChannel;
@@ -48,6 +51,7 @@ public abstract class LevelDbInputReader extends InputReader<ByteBuffer> {
 
   private long bytesRead;
   private ReadableByteChannel in;
+  private RestorableState<? extends ReadableByteChannel> channelState;
 
   public LevelDbInputReader() {
     this(LevelDbConstants.BLOCK_SIZE);
@@ -90,6 +94,7 @@ public abstract class LevelDbInputReader extends InputReader<ByteBuffer> {
     offset = 0;
     bytesRead = 0;
     in = createReadableByteChannel();
+    prepareForSerialization(); //technically, can serialize after here, before beginSlice()
   }
 
   /**
@@ -97,12 +102,34 @@ public abstract class LevelDbInputReader extends InputReader<ByteBuffer> {
    */
   @Override
   public void endShard() throws IOException {
-    in.close();
+    if (in != null) {
+      in.close();
+    }
   }
 
   @Override
   public void beginSlice() {
     tmpBuffer = allocate(blockSize);
+    if (in == null) {
+      in = channelState.restore();
+      channelState = null;
+    }
+  }
+
+  @Override
+  public void endSlice() throws IOException {
+    prepareForSerialization();
+    super.endSlice();
+  }
+
+  private void prepareForSerialization() {
+    //hacky, but maintains legacy implementation of LevelDbInputReader, which didn't require createReadableByteChannel()
+    // to return something serializable, but in practice expected it. This supports Restorable<> as alternative to serializable
+    if (!(in instanceof Serializable) && in instanceof Restorable<?>) {
+      channelState = ((Restorable<? extends ReadableByteChannel>) in).capture();
+      //q: should we close channel here??
+      in = null;
+    }
   }
 
   private static ByteBuffer allocate(int size) {

--- a/java/src/main/java/com/google/appengine/tools/mapreduce/outputs/BigQueryGoogleCloudStorageStoreOutput.java
+++ b/java/src/main/java/com/google/appengine/tools/mapreduce/outputs/BigQueryGoogleCloudStorageStoreOutput.java
@@ -32,13 +32,13 @@ public final class BigQueryGoogleCloudStorageStoreOutput<O> extends
    *        newline delimited json.
    */
   public BigQueryGoogleCloudStorageStoreOutput(BigQueryMarshaller<O> bigQueryMarshaller,
-      String bucketName, String fileNamePattern) {
+      String bucketName, String fileNamePattern, GoogleCloudStorageFileOutput.Options options) {
     this.bigQueryMarshaller = bigQueryMarshaller;
     this.bucketName = bucketName;
     this.fileNamePattern = fileNamePattern;
     SizeSegmentedGoogleCloudStorageFileOutput sizeSegmentedOutput =
         new SizeSegmentedGoogleCloudStorageFileOutput(this.bucketName, MAX_BIG_QUERY_GCS_FILE_SIZE,
-            String.format(GCS_FILE_NAME_FORMAT, this.fileNamePattern), MIME_TYPE);
+            String.format(GCS_FILE_NAME_FORMAT, this.fileNamePattern), MIME_TYPE, options);
     this.dataMarshallingOutput = new MarshallingOutput<>(sizeSegmentedOutput, bigQueryMarshaller);
   }
 

--- a/java/src/main/java/com/google/appengine/tools/mapreduce/outputs/GoogleCloudStorageFileOutput.java
+++ b/java/src/main/java/com/google/appengine/tools/mapreduce/outputs/GoogleCloudStorageFileOutput.java
@@ -1,6 +1,5 @@
 package com.google.appengine.tools.mapreduce.outputs;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.appengine.tools.cloudstorage.GcsFilename;
 import com.google.appengine.tools.mapreduce.GoogleCloudStorageFileSet;
@@ -8,6 +7,7 @@ import com.google.appengine.tools.mapreduce.Output;
 import com.google.appengine.tools.mapreduce.OutputWriter;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
+import lombok.*;
 
 import java.nio.ByteBuffer;
 import java.util.Collection;
@@ -20,13 +20,18 @@ import java.util.List;
  * cannot be read back with the CloudStorageLineInputReader.
  *
  */
+@RequiredArgsConstructor
 public class GoogleCloudStorageFileOutput extends Output<ByteBuffer, GoogleCloudStorageFileSet> {
   private static final long serialVersionUID = 5544139634754912546L;
 
-  private final String mimeType;
-  private final String fileNamePattern;
+  @NonNull
   private final String bucket;
-  private final boolean supportSliceRetries;
+  @NonNull
+  private final String fileNamePattern;
+  @NonNull
+  private final String mimeType;
+  @NonNull
+  private final GoogleCloudStorageFileOutputWriter.Options options;
 
   /**
    * Creates output files who's names follow the provided pattern in the specified bucket.
@@ -36,8 +41,9 @@ public class GoogleCloudStorageFileOutput extends Output<ByteBuffer, GoogleCloud
    *        argument for the shard number.
    * @param mimeType The string to be passed as the mimeType to GCS.
    */
+  @Deprecated
   public GoogleCloudStorageFileOutput(String bucket, String fileNamePattern, String mimeType) {
-    this(bucket, fileNamePattern, mimeType, true);
+    this(bucket, fileNamePattern, mimeType, GoogleCloudStorageFileOutputWriter.BaseOptions.defaults());
   }
 
   /**
@@ -50,12 +56,10 @@ public class GoogleCloudStorageFileOutput extends Output<ByteBuffer, GoogleCloud
    *        Slice retries are achieved by writing each slice to a temporary file
    *        and copying it to its destination when processing the next slice.
    */
+  @Deprecated
   public GoogleCloudStorageFileOutput(String bucket, String fileNamePattern, String mimeType,
       boolean supportSliceRetries) {
-    this.bucket = checkNotNull(bucket);
-    this.mimeType = checkNotNull(mimeType, "Null mimeType");
-    this.fileNamePattern = checkNotNull(fileNamePattern, "Null fileNamePattern");
-    this.supportSliceRetries = supportSliceRetries;
+    this(bucket, fileNamePattern, mimeType, GoogleCloudStorageFileOutputWriter.BaseOptions.defaults().withSupportSliceRetries(supportSliceRetries));
   }
 
   @Override
@@ -63,7 +67,7 @@ public class GoogleCloudStorageFileOutput extends Output<ByteBuffer, GoogleCloud
     ImmutableList.Builder<GoogleCloudStorageFileOutputWriter> out = ImmutableList.builder();
     for (int i = 0; i < numShards; i++) {
       GcsFilename file = new GcsFilename(bucket, String.format(fileNamePattern, i));
-      out.add(new GoogleCloudStorageFileOutputWriter(file, mimeType, supportSliceRetries));
+      out.add(new GoogleCloudStorageFileOutputWriter(file, mimeType, options));
     }
     return out.build();
   }

--- a/java/src/main/java/com/google/appengine/tools/mapreduce/outputs/GoogleCloudStorageFileOutput.java
+++ b/java/src/main/java/com/google/appengine/tools/mapreduce/outputs/GoogleCloudStorageFileOutput.java
@@ -4,15 +4,14 @@ import com.google.appengine.tools.mapreduce.GcsFilename;
 import com.google.appengine.tools.mapreduce.GoogleCloudStorageFileSet;
 import com.google.appengine.tools.mapreduce.Output;
 import com.google.appengine.tools.mapreduce.OutputWriter;
-import com.google.auth.Credentials;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import lombok.*;
 
+import javax.annotation.Nullable;
 import java.nio.ByteBuffer;
 import java.util.Collection;
 import java.util.List;
-import java.util.Optional;
 
 /**
  * An {@link Output} that writes bytes to a set of Cloud Storage files, one per shard.
@@ -106,16 +105,14 @@ public class GoogleCloudStorageFileOutput extends Output<ByteBuffer, GoogleCloud
     @Builder.Default
     private final Boolean supportSliceRetries = true;
 
-    private Credentials credentials;
-
+    @Nullable
     private String projectId;
+
+    @Nullable
+    private String serviceAccountKey;
 
     public static BaseOptions defaults() {
       return BaseOptions.builder().build();
-    }
-
-    public Optional<Credentials> getCredentials() {
-      return Optional.ofNullable(this.credentials);
     }
   }
 }

--- a/java/src/main/java/com/google/appengine/tools/mapreduce/outputs/GoogleCloudStorageFileOutput.java
+++ b/java/src/main/java/com/google/appengine/tools/mapreduce/outputs/GoogleCloudStorageFileOutput.java
@@ -1,7 +1,6 @@
 package com.google.appengine.tools.mapreduce.outputs;
 
-
-import com.google.appengine.tools.cloudstorage.GcsFilename;
+import com.google.appengine.tools.mapreduce.GcsFilename;
 import com.google.appengine.tools.mapreduce.GoogleCloudStorageFileSet;
 import com.google.appengine.tools.mapreduce.Output;
 import com.google.appengine.tools.mapreduce.OutputWriter;

--- a/java/src/main/java/com/google/appengine/tools/mapreduce/outputs/GoogleCloudStorageFileOutputWriter.java
+++ b/java/src/main/java/com/google/appengine/tools/mapreduce/outputs/GoogleCloudStorageFileOutputWriter.java
@@ -3,7 +3,7 @@ package com.google.appengine.tools.mapreduce.outputs;
 import static com.google.appengine.tools.mapreduce.impl.MapReduceConstants.DEFAULT_IO_BUFFER_SIZE;
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import com.google.appengine.tools.cloudstorage.GcsFilename;
+import com.google.appengine.tools.mapreduce.GcsFilename;
 import com.google.appengine.tools.mapreduce.OutputWriter;
 import com.google.appengine.tools.mapreduce.impl.MapReduceConstants;
 import com.google.auth.Credentials;
@@ -12,10 +12,7 @@ import com.google.cloud.WriteChannel;
 import com.google.cloud.storage.*;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.ToString;
-import lombok.With;
+import lombok.*;
 
 import java.io.IOException;
 import java.io.Serializable;
@@ -34,6 +31,7 @@ import java.util.logging.Logger;
  * it by default cannot be read back with the CloudStorageLineInputReader.
  *
  */
+@RequiredArgsConstructor
 @ToString
 public class GoogleCloudStorageFileOutputWriter extends OutputWriter<ByteBuffer> {
   private static final long serialVersionUID = 2L;
@@ -46,10 +44,10 @@ public class GoogleCloudStorageFileOutputWriter extends OutputWriter<ByteBuffer>
       MapReduceConstants.DEFAULT_IO_BUFFER_SIZE * 2;
   public static final long MEMORY_REQUIRED = MapReduceConstants.DEFAULT_IO_BUFFER_SIZE * 3;
 
-  //TODO: split this into bucket + objectName, or some other container that's not dependent on legacy GAE Storage client
-  private final GcsFilename file;
-  private final String mimeType;
-  private final Options options;
+  @Getter
+  @NonNull private final GcsFilename file;
+  @NonNull private final String mimeType;
+  @NonNull private final Options options;
 
   private transient Storage client;
   private BlobId shardBlobId;
@@ -86,13 +84,6 @@ public class GoogleCloudStorageFileOutputWriter extends OutputWriter<ByteBuffer>
     public Optional<Credentials> getCredentials() {
       return Optional.ofNullable(this.credentials);
     }
-  }
-
-
-  public GoogleCloudStorageFileOutputWriter(GcsFilename file, String mimeType, Options options) {
-    this.file = checkNotNull(file, "Null file");
-    this.mimeType = checkNotNull(mimeType, "Null mimeType");
-    this.options = options;
   }
 
   @Override
@@ -225,10 +216,6 @@ public class GoogleCloudStorageFileOutputWriter extends OutputWriter<ByteBuffer>
     toDelete.add(BlobId.of(shardBlobId.getBucket(), shardBlobId.getName()));
     shardBlobId = null;
     sliceChannel = null;
-  }
-
-  public GcsFilename getFile() {
-    return file;
   }
 
   @Override

--- a/java/src/main/java/com/google/appengine/tools/mapreduce/outputs/GoogleCloudStorageFileOutputWriter.java
+++ b/java/src/main/java/com/google/appengine/tools/mapreduce/outputs/GoogleCloudStorageFileOutputWriter.java
@@ -66,6 +66,29 @@ public class GoogleCloudStorageFileOutputWriter extends OutputWriter<ByteBuffer>
     String getProjectId();
   }
 
+  @Getter
+  @Builder
+  @With
+  @ToString
+  public static class BaseOptions implements Serializable, Options {
+
+    @Builder.Default
+    private final Boolean supportSliceRetries = true;
+
+    private Credentials credentials;
+
+    private String projectId;
+
+    public static BaseOptions defaults() {
+      return BaseOptions.builder().build();
+    }
+
+    public Optional<Credentials> getCredentials() {
+      return Optional.ofNullable(this.credentials);
+    }
+  }
+
+
   public GoogleCloudStorageFileOutputWriter(GcsFilename file, String mimeType, Options options) {
     this.file = checkNotNull(file, "Null file");
     this.mimeType = checkNotNull(mimeType, "Null mimeType");
@@ -208,25 +231,5 @@ public class GoogleCloudStorageFileOutputWriter extends OutputWriter<ByteBuffer>
     return MEMORY_REQUIRED;
   }
 
-  @Getter
-  @Builder
-  @With
-  @ToString
-  public static class BaseOptions implements Serializable, Options {
 
-    @Builder.Default
-    private final Boolean supportSliceRetries = true;
-
-    private Credentials credentials;
-
-    private String projectId;
-
-    public static BaseOptions defaults() {
-      return BaseOptions.builder().build();
-    }
-
-    public Optional<Credentials> getCredentials() {
-      return Optional.ofNullable(this.credentials);
-    }
-  }
 }

--- a/java/src/main/java/com/google/appengine/tools/mapreduce/outputs/GoogleCloudStorageFileOutputWriter.java
+++ b/java/src/main/java/com/google/appengine/tools/mapreduce/outputs/GoogleCloudStorageFileOutputWriter.java
@@ -1,27 +1,29 @@
 package com.google.appengine.tools.mapreduce.outputs;
 
 import static com.google.appengine.tools.mapreduce.impl.MapReduceConstants.DEFAULT_IO_BUFFER_SIZE;
-import static com.google.appengine.tools.mapreduce.impl.MapReduceConstants.GCS_RETRY_PARAMETERS;
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import com.google.appengine.tools.cloudstorage.GcsFileOptions;
 import com.google.appengine.tools.cloudstorage.GcsFilename;
-import com.google.appengine.tools.cloudstorage.GcsInputChannel;
-import com.google.appengine.tools.cloudstorage.GcsOutputChannel;
-import com.google.appengine.tools.cloudstorage.GcsService;
-import com.google.appengine.tools.cloudstorage.GcsServiceFactory;
-import com.google.appengine.tools.cloudstorage.GcsServiceOptions;
 import com.google.appengine.tools.mapreduce.OutputWriter;
 import com.google.appengine.tools.mapreduce.impl.MapReduceConstants;
+import com.google.auth.Credentials;
+import com.google.cloud.ReadChannel;
+import com.google.cloud.WriteChannel;
+import com.google.cloud.storage.*;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+import lombok.With;
 
 import java.io.IOException;
+import java.io.Serializable;
 import java.nio.ByteBuffer;
 import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.Random;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -32,57 +34,82 @@ import java.util.logging.Logger;
  * it by default cannot be read back with the CloudStorageLineInputReader.
  *
  */
+@ToString
 public class GoogleCloudStorageFileOutputWriter extends OutputWriter<ByteBuffer> {
-  private static final long serialVersionUID = -4019473590179157706L;
+  private static final long serialVersionUID = 2L;
   private static final Logger logger =
       Logger.getLogger(GoogleCloudStorageFileOutputWriter.class.getName());
-  private static final GcsService GCS_SERVICE = GcsServiceFactory.createGcsService(
-      new GcsServiceOptions.Builder()
-          .setRetryParams(GCS_RETRY_PARAMETERS)
-          .setDefaultWriteBufferSize(DEFAULT_IO_BUFFER_SIZE)
-          .setHttpHeaders(ImmutableMap.of("User-Agent", "App Engine MR"))
-          .build());
+
   private static final Random RND = new SecureRandom();
 
   public static final long MEMORY_REQUIRED_WITHOUT_SLICE_RETRY =
       MapReduceConstants.DEFAULT_IO_BUFFER_SIZE * 2;
   public static final long MEMORY_REQUIRED = MapReduceConstants.DEFAULT_IO_BUFFER_SIZE * 3;
 
+  //TODO: split this into bucket + objectName, or some other container that's not dependent on legacy GAE Storage client
   private final GcsFilename file;
   private final String mimeType;
-  private final boolean supportSliceRetries;
-  private GcsOutputChannel channel;
-  private GcsOutputChannel sliceChannel;
-  private final List<String> toDelete = new ArrayList<>();
+  private final Options options;
 
-  public GoogleCloudStorageFileOutputWriter(GcsFilename file, String mimeType) {
-    this(file, mimeType, true);
+  private transient Storage client;
+  private BlobId shardBlobId;
+  private BlobId sliceBlobId;
+  private transient WriteChannel sliceChannel;
+  private List<BlobId> toDelete = new ArrayList<>();
+
+  interface Options extends Serializable {
+
+    Boolean getSupportSliceRetries();
+
+    Optional<Credentials> getCredentials();
+
+    String getProjectId();
   }
 
-  public GoogleCloudStorageFileOutputWriter(GcsFilename file, String mimeType,
-      boolean supportSliceRetries) {
+  public GoogleCloudStorageFileOutputWriter(GcsFilename file, String mimeType, Options options) {
     this.file = checkNotNull(file, "Null file");
     this.mimeType = checkNotNull(mimeType, "Null mimeType");
-    this.supportSliceRetries = supportSliceRetries;
+    this.options = options;
   }
 
   @Override
   public void cleanup() {
-    for (String name : toDelete) {
+    for (BlobId id : toDelete) {
       try {
-        GCS_SERVICE.delete(new GcsFilename(file.getBucketName(), name));
-      } catch (IOException ex) {
-        logger.log(Level.WARNING, "Could not cleanup temporary file " + name, ex);
+        getClient().delete(id);
+      } catch (StorageException ex) {
+        logger.log(Level.WARNING, "Could not cleanup temporary file " + id.getName(), ex);
       }
     }
     toDelete.clear();
   }
 
+
+
+  protected Storage getClient() {
+    if (client == null) {
+      //TODO: set retry param (GCS_RETRY_PARAMETERS)
+      //TODO: set User-Agent to "App Engine MR"?
+      if (this.options.getCredentials().isPresent()) {
+        client = StorageOptions.newBuilder()
+          .setCredentials(this.options.getCredentials().get())
+          .setProjectId(this.options.getProjectId())
+          .build().getService();
+      } else {
+        client = StorageOptions.getDefaultInstance().getService();
+      }
+    }
+    return client;
+  }
+
   @Override
   public void beginShard() throws IOException {
-    GcsFileOptions fileOptions = new GcsFileOptions.Builder().mimeType(mimeType).build();
-    GcsFilename dest = new GcsFilename(file.getBucketName(), file.getObjectName() + "~");
-    channel = GCS_SERVICE.createOrReplace(dest, fileOptions);
+
+    BlobInfo blobInfo = BlobInfo.newBuilder(file.getBucketName(), file.getObjectName() + "~")
+      .setContentType(mimeType)
+      .build();
+    Blob shardBlob = getClient().create(blobInfo);
+    shardBlobId = BlobId.of(shardBlob.getBucket(), shardBlob.getName());
     sliceChannel = null;
     toDelete.clear();
   }
@@ -90,30 +117,46 @@ public class GoogleCloudStorageFileOutputWriter extends OutputWriter<ByteBuffer>
   @Override
   public void beginSlice() throws IOException {
     cleanup();
-    if (supportSliceRetries) {
-      if (sliceChannel != null) {
-        copy(sliceChannel.getFilename(), channel);
-        toDelete.add(sliceChannel.getFilename().getObjectName());
+    if (options.getSupportSliceRetries()) {
+      if (sliceBlobId != null) {
+        //append latest version of previous slice's file to shard's file
+        // q: why not do this in endSlice??
+        // q: why are we doing this as part of every slice? why not just do a big compose of all slices
+        // into shard at endShard?
+        BlobId latestSliceBlobId = BlobId.of(sliceBlobId.getBucket(), sliceBlobId.getName());
+
+        //q: race condition here? what if this append() doesn't really see the 'latest' copy of blob?
+        append(latestSliceBlobId, shardBlobId);
+        toDelete.add(latestSliceBlobId);
       }
-      GcsFileOptions opt = new GcsFileOptions.Builder().mimeType(mimeType).build();
       String name = file.getObjectName() + "~" + Math.abs(RND.nextLong());
-      sliceChannel = GCS_SERVICE.createOrReplace(new GcsFilename(file.getBucketName(), name), opt);
+      Blob sliceBlob = getClient().create(BlobInfo.newBuilder(file.getBucketName(), name)
+        .setContentType(mimeType).build());
+      sliceBlobId = BlobId.of(sliceBlob.getBucket(), sliceBlob.getName());
+      sliceChannel = sliceBlob.writer();
     } else {
-      sliceChannel = channel;
+      //if won't retry slices, can just write straight into shard's blob
+      sliceChannel = getClient().get(shardBlobId).writer();
     }
+    sliceChannel.setChunkSize(DEFAULT_IO_BUFFER_SIZE);
   }
 
-  private static void copy(GcsFilename from, GcsOutputChannel toChannel) throws IOException {
+
+  void append(BlobId src, BlobId dest) throws IOException {
     ByteBuffer buffer = ByteBuffer.allocate(MapReduceConstants.DEFAULT_IO_BUFFER_SIZE);
-    try (GcsInputChannel fromChannel = GCS_SERVICE.openReadChannel(from, 0)) {
-      while (fromChannel.read(buffer) >= 0) {
+    WriteChannel destChannel =
+      getClient().writer(BlobInfo.newBuilder(dest.getBucket(), dest.getName()).build());
+    try (ReadChannel reader = getClient().reader(src)) {
+      while (reader.read(buffer) >= 0) {
         buffer.flip();
         while (buffer.hasRemaining()) {
-          toChannel.write(buffer);
+          destChannel.write(buffer);
         }
         buffer.clear();
       }
     }
+    destChannel.close();
+    //q: return dest with updated version number? (generation ID?)
   }
 
   @Override
@@ -126,33 +169,34 @@ public class GoogleCloudStorageFileOutputWriter extends OutputWriter<ByteBuffer>
 
   @Override
   public void endSlice() throws IOException {
-    if (supportSliceRetries) {
-      sliceChannel.close();
-    }
-    channel.waitForOutstandingWrites();
+    sliceChannel.close();
   }
 
   @Override
   public void endShard() throws IOException {
-    if (channel == null) {
+    if (sliceBlobId == null) {
       return;
     }
-    channel.close();
-    if (supportSliceRetries && sliceChannel != null) {
+    if (options.getSupportSliceRetries() && sliceChannel != null) {
       // compose temporary destination and last slice to final destination
-      List<String> source = ImmutableList.of(channel.getFilename().getObjectName(),
-          sliceChannel.getFilename().getObjectName());
-      GcsFileOptions opt = new GcsFileOptions.Builder().mimeType(mimeType).build();
-      GCS_SERVICE.compose(source, file);
-      GCS_SERVICE.update(file, opt);
-      toDelete.add(sliceChannel.getFilename().getObjectName());
-      sliceChannel = null;
+      List<String> source = ImmutableList.of(shardBlobId.getName(), sliceBlobId.getName());
+      BlobInfo dest = BlobInfo.newBuilder(file.getBucketName(), file.getObjectName())
+        .setContentType(this.mimeType)
+        .build();
+      getClient().compose(Storage.ComposeRequest.of(source, dest));
     } else {
       // rename temporary destination to final destination
-      GCS_SERVICE.copy(channel.getFilename(), file);
+      //q: race condition here? what if this copy() doesn't really see the 'latest' copy of sliceBlob?
+      // is there a way to get the latest generation number from our last write, so that we can make
+      // this copy request contingent upon seeing that??
+
+      getClient().copy(Storage.CopyRequest.of(BlobId.of(sliceBlobId.getBucket(), sliceBlobId.getName()), BlobInfo.newBuilder(file.getBucketName(), file.getObjectName()).build()));
     }
-    toDelete.add(channel.getFilename().getObjectName());
-    channel = null;
+
+    //queue blob for deletion
+    toDelete.add(BlobId.of(shardBlobId.getBucket(), shardBlobId.getName()));
+    shardBlobId = null;
+    sliceChannel = null;
   }
 
   public GcsFilename getFile() {
@@ -160,14 +204,29 @@ public class GoogleCloudStorageFileOutputWriter extends OutputWriter<ByteBuffer>
   }
 
   @Override
-  public String toString() {
-    return "GoogleCloudStorageFileOutputWriter [file=" + file + ", mimeType=" + mimeType
-        + ", channel=" + channel + ", supportSliceRetries= " + supportSliceRetries
-        + ", sliceChannel=" + sliceChannel + ", toDelete=" + toDelete + "]";
-  }
-
-  @Override
   public long estimateMemoryRequirement() {
     return MEMORY_REQUIRED;
+  }
+
+  @Getter
+  @Builder
+  @With
+  @ToString
+  public static class BaseOptions implements Serializable, Options {
+
+    @Builder.Default
+    private final Boolean supportSliceRetries = true;
+
+    private Credentials credentials;
+
+    private String projectId;
+
+    public static BaseOptions defaults() {
+      return BaseOptions.builder().build();
+    }
+
+    public Optional<Credentials> getCredentials() {
+      return Optional.ofNullable(this.credentials);
+    }
   }
 }

--- a/java/src/main/java/com/google/appengine/tools/mapreduce/outputs/GoogleCloudStorageFileOutputWriter.java
+++ b/java/src/main/java/com/google/appengine/tools/mapreduce/outputs/GoogleCloudStorageFileOutputWriter.java
@@ -8,6 +8,7 @@ import com.google.appengine.tools.mapreduce.OutputWriter;
 import com.google.appengine.tools.mapreduce.impl.MapReduceConstants;
 import com.google.auth.Credentials;
 import com.google.cloud.ReadChannel;
+import com.google.cloud.RestorableState;
 import com.google.cloud.WriteChannel;
 import com.google.cloud.storage.*;
 import com.google.common.base.Preconditions;

--- a/java/src/main/java/com/google/appengine/tools/mapreduce/outputs/GoogleCloudStorageFileOutputWriter.java
+++ b/java/src/main/java/com/google/appengine/tools/mapreduce/outputs/GoogleCloudStorageFileOutputWriter.java
@@ -1,7 +1,7 @@
 package com.google.appengine.tools.mapreduce.outputs;
 
 import static com.google.appengine.tools.mapreduce.impl.MapReduceConstants.DEFAULT_IO_BUFFER_SIZE;
-import static com.google.common.base.Preconditions.checkNotNull;
+
 
 import com.google.appengine.tools.mapreduce.GcsFilename;
 import com.google.appengine.tools.mapreduce.OutputWriter;
@@ -55,35 +55,12 @@ public class GoogleCloudStorageFileOutputWriter extends OutputWriter<ByteBuffer>
   private transient WriteChannel sliceChannel;
   private List<BlobId> toDelete = new ArrayList<>();
 
-  interface Options extends Serializable {
-
+  public interface Options extends Serializable {
     Boolean getSupportSliceRetries();
 
     Optional<Credentials> getCredentials();
 
     String getProjectId();
-  }
-
-  @Getter
-  @Builder
-  @With
-  @ToString
-  public static class BaseOptions implements Serializable, Options {
-
-    @Builder.Default
-    private final Boolean supportSliceRetries = true;
-
-    private Credentials credentials;
-
-    private String projectId;
-
-    public static BaseOptions defaults() {
-      return BaseOptions.builder().build();
-    }
-
-    public Optional<Credentials> getCredentials() {
-      return Optional.ofNullable(this.credentials);
-    }
   }
 
   @Override

--- a/java/src/main/java/com/google/appengine/tools/mapreduce/outputs/GoogleCloudStorageFileOutputWriter.java
+++ b/java/src/main/java/com/google/appengine/tools/mapreduce/outputs/GoogleCloudStorageFileOutputWriter.java
@@ -60,7 +60,9 @@ public class GoogleCloudStorageFileOutputWriter extends OutputWriter<ByteBuffer>
 
     Optional<Credentials> getCredentials();
 
-    String getProjectId();
+    String getProjectId(); //think only needed if creating bucket? which this shouldn't be ..
+
+    Options withSupportSliceRetries(Boolean sliceRetries);
   }
 
   @Override

--- a/java/src/main/java/com/google/appengine/tools/mapreduce/outputs/GoogleCloudStorageFileOutputWriter.java
+++ b/java/src/main/java/com/google/appengine/tools/mapreduce/outputs/GoogleCloudStorageFileOutputWriter.java
@@ -206,6 +206,11 @@ public class GoogleCloudStorageFileOutputWriter extends OutputWriter<ByteBuffer>
       BlobInfo dest = BlobInfo.newBuilder(file.getBucketName(), file.getObjectName())
         .setContentType(this.mimeType)
         .build();
+      // unclear that we can "compose" if also using customer-managed encryption keys because:
+      // https://cloud.google.com/storage/docs/encryption/customer-managed-keys#key-resources
+      // "when one or more of the source objects are encrypted with a customer-managed encryption key."
+      // but https://cloud.google.com/storage/docs/json_api/v1/objects/compose
+      // says "To compose objects encrypted by a customer-supplied encryption key, use the headers listed on the Encryption page in your request."
       getClient().compose(Storage.ComposeRequest.of(source, dest));
     } else {
       // rename temporary destination to final destination

--- a/java/src/main/java/com/google/appengine/tools/mapreduce/outputs/GoogleCloudStorageLevelDbOutput.java
+++ b/java/src/main/java/com/google/appengine/tools/mapreduce/outputs/GoogleCloudStorageLevelDbOutput.java
@@ -27,7 +27,11 @@ public class GoogleCloudStorageLevelDbOutput extends Output<ByteBuffer, GoogleCl
    * @param mimeType The string to be passed as the mimeType to GCS.
    */
   public GoogleCloudStorageLevelDbOutput(String bucket, String fileNamePattern, String mimeType) {
-    output = new GoogleCloudStorageFileOutput(bucket, fileNamePattern, mimeType);
+    output = new GoogleCloudStorageFileOutput(bucket, fileNamePattern, mimeType, GoogleCloudStorageFileOutput.BaseOptions.defaults());
+  }
+
+  public GoogleCloudStorageLevelDbOutput(String bucket, String fileNamePattern, String mimeType, GoogleCloudStorageFileOutput.Options options) {
+    output = new GoogleCloudStorageFileOutput(bucket, fileNamePattern, mimeType, options);
   }
 
   /**
@@ -38,10 +42,11 @@ public class GoogleCloudStorageLevelDbOutput extends Output<ByteBuffer, GoogleCl
    * @param mimeType The string to be passed as the mimeType to GCS.
    * @param supportSliceRetries indicates if slice retries should be supported by this writer.
    */
+  @Deprecated //use Options version
   public GoogleCloudStorageLevelDbOutput(String bucket, String fileNamePattern, String mimeType,
       boolean supportSliceRetries) {
     output =
-        new GoogleCloudStorageFileOutput(bucket, fileNamePattern, mimeType, supportSliceRetries);
+        new GoogleCloudStorageFileOutput(bucket, fileNamePattern, mimeType, GoogleCloudStorageFileOutput.BaseOptions.defaults().withSupportSliceRetries(supportSliceRetries));
   }
 
   @Override

--- a/java/src/main/java/com/google/appengine/tools/mapreduce/outputs/SizeSegmentedGoogleCloudStorageFileOutput.java
+++ b/java/src/main/java/com/google/appengine/tools/mapreduce/outputs/SizeSegmentedGoogleCloudStorageFileOutput.java
@@ -73,7 +73,7 @@ public final class SizeSegmentedGoogleCloudStorageFileOutput extends
     protected OutputWriter<ByteBuffer> createWriter(int fileNum) {
       String fileName = String.format(fileNamePattern, shardNumber, System.currentTimeMillis());
       GoogleCloudStorageFileOutputWriter toReturn =
-          new GoogleCloudStorageFileOutputWriter(new GcsFilename(bucket, fileName), mimeType);
+          new GoogleCloudStorageFileOutputWriter(new GcsFilename(bucket, fileName), mimeType, GoogleCloudStorageFileOutputWriter.BaseOptions.defaults().withSupportSliceRetries(false));
       delegatedWriters.add(toReturn);
       return toReturn;
     }

--- a/java/src/main/java/com/google/appengine/tools/mapreduce/outputs/SizeSegmentedGoogleCloudStorageFileOutput.java
+++ b/java/src/main/java/com/google/appengine/tools/mapreduce/outputs/SizeSegmentedGoogleCloudStorageFileOutput.java
@@ -2,7 +2,7 @@ package com.google.appengine.tools.mapreduce.outputs;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import com.google.appengine.tools.cloudstorage.GcsFilename;
+import com.google.appengine.tools.mapreduce.GcsFilename;
 import com.google.appengine.tools.mapreduce.GoogleCloudStorageFileSet;
 import com.google.appengine.tools.mapreduce.Output;
 import com.google.appengine.tools.mapreduce.OutputWriter;

--- a/java/src/main/java/com/google/appengine/tools/mapreduce/outputs/SizeSegmentedGoogleCloudStorageFileOutput.java
+++ b/java/src/main/java/com/google/appengine/tools/mapreduce/outputs/SizeSegmentedGoogleCloudStorageFileOutput.java
@@ -7,6 +7,7 @@ import com.google.appengine.tools.mapreduce.GoogleCloudStorageFileSet;
 import com.google.appengine.tools.mapreduce.Output;
 import com.google.appengine.tools.mapreduce.OutputWriter;
 import com.google.common.collect.ImmutableList;
+import lombok.NonNull;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -27,6 +28,9 @@ public final class SizeSegmentedGoogleCloudStorageFileOutput extends
   private final long segmentSizeLimit;
   private final String fileNamePattern;
 
+  @NonNull
+  private final GoogleCloudStorageFileOutput.Options options;
+
   /**
    * @param bucket GCS bucket
    * @param segmentSizeLimit Maximum size of the files to be written to the output
@@ -36,11 +40,12 @@ public final class SizeSegmentedGoogleCloudStorageFileOutput extends
    * @param mimeType The string to be passed as the mimeType to GCS.
    */
   public SizeSegmentedGoogleCloudStorageFileOutput(String bucket, long segmentSizeLimit,
-      String fileNamePattern, String mimeType) {
+      String fileNamePattern, String mimeType, GoogleCloudStorageFileOutput.Options  options) {
     this.bucket = checkNotNull(bucket, "Null bucket");
     this.segmentSizeLimit = segmentSizeLimit;
     this.fileNamePattern = checkNotNull(fileNamePattern, "Null file name pattern");
     this.mimeType = checkNotNull(mimeType, "Null mime type");
+    this.options = options;
   }
 
   private static class SizeSegmentingGoogleCloudStorageFileWriter extends
@@ -51,7 +56,11 @@ public final class SizeSegmentedGoogleCloudStorageFileOutput extends
     private final String fileNamePattern;
     private final String mimeType;
     private final int shardNumber;
+    @NonNull
+    private final GoogleCloudStorageFileOutput.Options options;
     private final List<GoogleCloudStorageFileOutputWriter> delegatedWriters;
+
+
 
     /**
      * @param bucket
@@ -60,20 +69,21 @@ public final class SizeSegmentedGoogleCloudStorageFileOutput extends
      * @param segmentSizeLimit Maximum size of the files to be written out by this writer
      */
     public SizeSegmentingGoogleCloudStorageFileWriter(String bucket, String fileNamePattern,
-        int shardNumber, String mimeType, long segmentSizeLimit) {
+        int shardNumber, String mimeType, long segmentSizeLimit, GoogleCloudStorageFileOutput.Options options) {
       super(segmentSizeLimit);
       this.bucket = checkNotNull(bucket, "Null bucket");
       this.fileNamePattern = checkNotNull(fileNamePattern, "Null fileNamePattern");
       this.mimeType = checkNotNull(mimeType, "Null mime type");
       this.shardNumber = shardNumber;
       delegatedWriters = new ArrayList<>();
+      this.options = options;
     }
 
     @Override
     protected OutputWriter<ByteBuffer> createWriter(int fileNum) {
       String fileName = String.format(fileNamePattern, shardNumber, System.currentTimeMillis());
       GoogleCloudStorageFileOutputWriter toReturn =
-          new GoogleCloudStorageFileOutputWriter(new GcsFilename(bucket, fileName), mimeType, GoogleCloudStorageFileOutputWriter.BaseOptions.defaults().withSupportSliceRetries(false));
+          new GoogleCloudStorageFileOutputWriter(new GcsFilename(bucket, fileName), mimeType, this.options);
       delegatedWriters.add(toReturn);
       return toReturn;
     }
@@ -103,7 +113,7 @@ public final class SizeSegmentedGoogleCloudStorageFileOutput extends
         new ImmutableList.Builder<>();
     for (int i = 0; i < numShards; ++i) {
       result.add(new SizeSegmentingGoogleCloudStorageFileWriter(bucket, fileNamePattern, i,
-          mimeType, segmentSizeLimit));
+          mimeType, segmentSizeLimit, options));
     }
     return result.build();
   }

--- a/java/src/main/java/com/google/appengine/tools/mapreduce/servlets/ShufflerParams.java
+++ b/java/src/main/java/com/google/appengine/tools/mapreduce/servlets/ShufflerParams.java
@@ -14,17 +14,22 @@
 
 package com.google.appengine.tools.mapreduce.servlets;
 
-import com.google.auth.Credentials;
+import com.google.appengine.tools.mapreduce.GcpCredentialOptions;
+import com.google.auth.oauth2.ServiceAccountCredentials;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import java.io.Serializable;
+import java.util.Base64;
+import java.util.Optional;
 
 @AllArgsConstructor
 @NoArgsConstructor
 @Data
-class ShufflerParams implements Serializable {
+class ShufflerParams implements Serializable, GcpCredentialOptions {
 
   private static final long serialVersionUID = 2L;
 
@@ -32,11 +37,7 @@ class ShufflerParams implements Serializable {
   private String gcsBucket;
   private String[] inputFileNames;
   private String outputDir;
-
-  /**
-   * credentials to use when accessing GCS bucket for shuffling
-   */
-  private Credentials credentials;
+  private String serviceAccountKey;
 
   private int outputShards;
   private String callbackQueue;

--- a/java/src/main/java/com/google/appengine/tools/mapreduce/servlets/ShufflerParams.java
+++ b/java/src/main/java/com/google/appengine/tools/mapreduce/servlets/ShufflerParams.java
@@ -14,12 +14,18 @@
 
 package com.google.appengine.tools.mapreduce.servlets;
 
-import java.io.Serializable;
-import java.util.Arrays;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
+import java.io.Serializable;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
 class ShufflerParams implements Serializable {
 
-  private static final long serialVersionUID = 1381831224713193323L;
+  private static final long serialVersionUID = 2L;
 
   private String shufflerQueue;
   private String gcsBucket;
@@ -28,129 +34,9 @@ class ShufflerParams implements Serializable {
 
   private int outputShards;
   private String callbackQueue;
-  private String callbackModule;
+  private String callbackService;
   private String callbackVersion;
   private String callbackPath;
-
-  ShufflerParams() {} // Needed by json
-
-  /**
-   * @return the shufflerQueue
-   */
-  public String getShufflerQueue() {
-    return shufflerQueue;
-  }
-
-  /**
-   * @param shufflerQueue the shufflerQueue to set
-   */
-  public void setShufflerQueue(String shufflerQueue) {
-    this.shufflerQueue = shufflerQueue;
-  }
-
-  /**
-   * @return the gcsBucket
-   */
-  public String getGcsBucket() {
-    return gcsBucket;
-  }
-
-  /**
-   * @param gcsBucket the gcsBucket to set
-   */
-  public void setGcsBucket(String gcsBucket) {
-    this.gcsBucket = gcsBucket;
-  }
-
-  /**
-   * @return the inputFileNames
-   */
-  public String[] getInputFileNames() {
-    return inputFileNames;
-  }
-
-  /**
-   * @param inputFileNames the inputFileNames to set
-   */
-  public void setInputFileNames(String[] inputFileNames) {
-    this.inputFileNames = inputFileNames;
-  }
-
-  /**
-   * @return the outputDir
-   */
-  public String getOutputDir() {
-    if (outputDir == null) {
-      return "";
-    }
-    if (outputDir.endsWith("/")) {
-      return outputDir.substring(0, outputDir.length() - 1);
-    }
-    return outputDir;
-  }
-
-  /**
-   * @param outputDir the outputDir to set
-   */
-  public void setOutputDir(String outputDir) {
-    this.outputDir = outputDir;
-  }
-
-  /**
-   * @return the outputShards
-   */
-  public int getOutputShards() {
-    return outputShards;
-  }
-
-  /**
-   * @param outputShards the outputShards to set
-   */
-  public void setOutputShards(int outputShards) {
-    this.outputShards = outputShards;
-  }
-
-  /**
-   * @return the callbackQueue
-   */
-  public String getCallbackQueue() {
-    return callbackQueue;
-  }
-
-  /**
-   * @param callbackQueue the callbackQueue to set
-   */
-  public void setCallbackQueue(String callbackQueue) {
-    this.callbackQueue = callbackQueue;
-  }
-
-  /**
-   * @return the callbackModule
-   */
-  public String getCallbackModule() {
-    return callbackModule;
-  }
-
-  /**
-   * @param callbackModule the callbackModule to set
-   */
-  public void setCallbackModule(String callbackModule) {
-    this.callbackModule = callbackModule;
-  }
-
-  /**
-   * @return the callbackVersion
-   */
-  public String getCallbackVersion() {
-    return callbackVersion;
-  }
-
-  /**
-   * @param callbackVersion the callbackVersion to set
-   */
-  public void setCallbackVersion(String callbackVersion) {
-    this.callbackVersion = callbackVersion;
-  }
 
   /**
    * @return the callbackPath
@@ -162,19 +48,4 @@ class ShufflerParams implements Serializable {
     return callbackPath;
   }
 
-  /**
-   * @param callbackPath the callbackPath to set
-   */
-  public void setCallbackPath(String callbackPath) {
-    this.callbackPath = callbackPath;
-  }
-
-  @Override
-  public String toString() {
-    return "ShufflerParams [shufflerQueue=" + shufflerQueue + ", gcsBucket=" + gcsBucket
-        + ", outputDir=" + outputDir + ", inputFileNames=" + Arrays.toString(inputFileNames)
-        + ", outputShards=" + outputShards + ", callbackQueue=" + callbackQueue
-        + ", callbackModule=" + callbackModule + ", callbackVersion=" + callbackVersion
-        + ", callbackPath=" + callbackPath + "]";
-  }
 }

--- a/java/src/main/java/com/google/appengine/tools/mapreduce/servlets/ShufflerParams.java
+++ b/java/src/main/java/com/google/appengine/tools/mapreduce/servlets/ShufflerParams.java
@@ -14,6 +14,7 @@
 
 package com.google.appengine.tools.mapreduce.servlets;
 
+import com.google.auth.Credentials;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -31,6 +32,11 @@ class ShufflerParams implements Serializable {
   private String gcsBucket;
   private String[] inputFileNames;
   private String outputDir;
+
+  /**
+   * credentials to use when accessing GCS bucket for shuffling
+   */
+  private Credentials credentials;
 
   private int outputShards;
   private String callbackQueue;

--- a/java/src/main/java/com/google/appengine/tools/mapreduce/servlets/ShufflerServlet.java
+++ b/java/src/main/java/com/google/appengine/tools/mapreduce/servlets/ShufflerServlet.java
@@ -104,9 +104,9 @@ public class ShufflerServlet extends HttpServlet {
   @VisibleForTesting
   static final class ShuffleMapReduce extends Job0<Void> {
 
-    private static final long serialVersionUID = 7223668152902598033L;
+    private static final long serialVersionUID = 2L;
 
-    private final Marshaller<ByteBuffer> idenityMarshaller = Marshallers.getByteBufferMarshaller();
+    private final Marshaller<ByteBuffer> identityMarshaller = Marshallers.getByteBufferMarshaller();
 
     private final ShufflerParams shufflerParams;
 
@@ -142,8 +142,8 @@ public class ShufflerServlet extends HttpServlet {
           .setReducer(new IdentityReducer<ByteBuffer, ByteBuffer>(MAX_VALUES_COUNT))
           .setOutput(createOutput())
           .setJobName("Shuffle")
-          .setKeyMarshaller(idenityMarshaller)
-          .setValueMarshaller(idenityMarshaller)
+          .setKeyMarshaller(identityMarshaller)
+          .setValueMarshaller(identityMarshaller)
           .setNumReducers(shufflerParams.getOutputShards())
           .build();
     }
@@ -153,7 +153,7 @@ public class ShufflerServlet extends HttpServlet {
       String jobId = getPipelineKey().getName();
       return new MarshallingOutput<>(new GoogleCloudStorageLevelDbOutput(
           shufflerParams.getGcsBucket(), getOutputNamePattern(jobId), MIME_TYPE),
-          Marshallers.getKeyValuesMarshaller(idenityMarshaller, idenityMarshaller));
+          Marshallers.getKeyValuesMarshaller(identityMarshaller, identityMarshaller));
     }
 
     @VisibleForTesting
@@ -165,7 +165,7 @@ public class ShufflerServlet extends HttpServlet {
       List<String> fileNames = Arrays.asList(shufflerParams.getInputFileNames());
       return new UnmarshallingInput<>(new GoogleCloudStorageLevelDbInput(
           new GoogleCloudStorageFileSet(shufflerParams.getGcsBucket(), fileNames)),
-          Marshallers.getKeyValueMarshaller(idenityMarshaller, idenityMarshaller));
+          Marshallers.getKeyValueMarshaller(identityMarshaller, identityMarshaller));
     }
 
     /**

--- a/java/src/main/java/com/google/appengine/tools/mapreduce/servlets/ShufflerServlet.java
+++ b/java/src/main/java/com/google/appengine/tools/mapreduce/servlets/ShufflerServlet.java
@@ -132,7 +132,7 @@ public class ShufflerServlet extends HttpServlet {
     }
 
     private MapReduceSpecification<KeyValue<ByteBuffer, ByteBuffer>, ByteBuffer, ByteBuffer,
-      KeyValue<ByteBuffer, ? extends Iterable<ByteBuffer>>, GoogleCloudStorageFileSet> 
+      KeyValue<ByteBuffer, ? extends Iterable<ByteBuffer>>, GoogleCloudStorageFileSet>
         createSpec() {
       return new MapReduceSpecification.Builder<KeyValue<ByteBuffer, ByteBuffer>, ByteBuffer,
           ByteBuffer, KeyValue<ByteBuffer, ? extends Iterable<ByteBuffer>>,
@@ -203,7 +203,7 @@ public class ShufflerServlet extends HttpServlet {
       GcsOutputChannel output = gcsService.createOrReplace(
           new GcsFilename(shufflerParams.getGcsBucket(), manifestPath),
           new GcsFileOptions.Builder().mimeType("text/plain").build());
-      for (GcsFilename fileName : result.getOutputResult().getFiles()) {
+      for (com.google.appengine.tools.mapreduce.GcsFilename fileName : result.getOutputResult().getFiles()) {
         output.write(StandardCharsets.UTF_8.encode(fileName.getObjectName()));
         output.write(StandardCharsets.UTF_8.encode("\n"));
       }

--- a/java/src/main/java/com/google/appengine/tools/mapreduce/servlets/ShufflerServlet.java
+++ b/java/src/main/java/com/google/appengine/tools/mapreduce/servlets/ShufflerServlet.java
@@ -225,7 +225,7 @@ public class ShufflerServlet extends HttpServlet {
       @Override
       public void run() {
         String hostname = ModulesServiceFactory.getModulesService().getVersionHostname(
-            shufflerParams.getCallbackModule(), shufflerParams.getCallbackVersion());
+            shufflerParams.getCallbackService(), shufflerParams.getCallbackVersion());
         Queue queue = QueueFactory.getQueue(shufflerParams.getCallbackQueue());
         String separater = shufflerParams.getCallbackPath().contains("?") ? "&" : "?";
         try {
@@ -258,7 +258,7 @@ public class ShufflerServlet extends HttpServlet {
     if (params.getGcsBucket() == null) {
       throw new IllegalArgumentException("GcsBucket parameter is mandatory");
     }
-    if (params.getCallbackModule() == null || params.getCallbackVersion() == null) {
+    if (params.getCallbackService() == null || params.getCallbackVersion() == null) {
       throw new IllegalArgumentException(
           "CallbackModule and CallbackVersion parameters are mandatory");
     }

--- a/java/src/test/java/com/google/appengine/tools/mapreduce/CloudStorageIntegrationTestCase.java
+++ b/java/src/test/java/com/google/appengine/tools/mapreduce/CloudStorageIntegrationTestCase.java
@@ -1,0 +1,72 @@
+package com.google.appengine.tools.mapreduce;
+
+import com.google.auth.Credentials;
+import com.google.auth.oauth2.ServiceAccountCredentials;
+import com.google.cloud.storage.BucketInfo;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.testing.RemoteStorageHelper;
+import junit.framework.TestCase;
+import lombok.Getter;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.util.Base64;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * sets up storage bucket for tests
+ *
+ * as of Apr 2020, no gcs emulator https://cloud.google.com/sdk/gcloud/reference/beta/emulators
+ *
+ * @see "https://googleapis.dev/java/google-cloud-storage/1.106.0/com/google/cloud/storage/testing/RemoteStorageHelper.html"
+ *
+ * eg,
+ *   1. create SA in target project; give it "Storage Admin" role
+ *   2. cat ~/Downloads/worklytics-ci-111242f427df.json | base64
+ *   3. set output of that as your env variable
+ *    - in IntelliJ, set this via RunConfigurations --> Env Variables.
+ *    - in GitHub, set it as via repo --> Settings --> Secrets so it can be utilized in workflows
+ *
+ * q: better to have a helper class for this? analogous to
+ * @see com.google.appengine.tools.development.testing.LocalServiceTestHelper
+ */
+public class CloudStorageIntegrationTestCase extends TestCase {
+
+  public final String KEY_ENV_VAR = "APPENGINE_MAPREDUCE_CI_SERVICE_ACCOUNT_KEY";
+
+  @Getter
+  Storage storage;
+  @Getter
+  String bucket;
+  @Getter
+  String projectId;
+  @Getter
+  Credentials credentials;
+
+  @Override
+  protected void setUp() throws Exception {
+    super.setUp();
+
+    String keyVar = System.getenv(KEY_ENV_VAR);
+    if (keyVar == null) {
+      throw new IllegalStateException("Must set environment variable " + KEY_ENV_VAR + " as base64 encoded service account key to use for storage integration tests");
+    }
+    keyVar = keyVar.trim();
+    String jsonKey = new String(Base64.getDecoder().decode(keyVar.getBytes()));
+
+    credentials = ServiceAccountCredentials.fromStream(new ByteArrayInputStream(jsonKey.getBytes()));
+    projectId = ((ServiceAccountCredentials) credentials).getProjectId();
+
+    InputStream keyStream = new ByteArrayInputStream(jsonKey.getBytes());
+    RemoteStorageHelper helper = RemoteStorageHelper.create(projectId, keyStream);
+    storage = helper.getOptions().getService();
+    bucket = RemoteStorageHelper.generateBucketName();
+    storage.create(BucketInfo.of(bucket));
+  }
+
+  @Override
+  protected void tearDown() throws Exception {
+    super.tearDown();
+    RemoteStorageHelper.forceDelete(storage, bucket, 5, TimeUnit.SECONDS);
+  }
+}

--- a/java/src/test/java/com/google/appengine/tools/mapreduce/CloudStorageIntegrationTestHelper.java
+++ b/java/src/test/java/com/google/appengine/tools/mapreduce/CloudStorageIntegrationTestHelper.java
@@ -1,12 +1,13 @@
 package com.google.appengine.tools.mapreduce;
 
+import com.google.appengine.tools.development.testing.LocalServiceTestConfig;
 import com.google.auth.Credentials;
 import com.google.auth.oauth2.ServiceAccountCredentials;
 import com.google.cloud.storage.BucketInfo;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.testing.RemoteStorageHelper;
-import junit.framework.TestCase;
 import lombok.Getter;
+import lombok.SneakyThrows;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
@@ -30,7 +31,7 @@ import java.util.concurrent.TimeUnit;
  * q: better to have a helper class for this? analogous to
  * @see com.google.appengine.tools.development.testing.LocalServiceTestHelper
  */
-public class CloudStorageIntegrationTestCase extends TestCase {
+public class CloudStorageIntegrationTestHelper implements LocalServiceTestConfig {
 
   public final String KEY_ENV_VAR = "APPENGINE_MAPREDUCE_CI_SERVICE_ACCOUNT_KEY";
 
@@ -43,9 +44,9 @@ public class CloudStorageIntegrationTestCase extends TestCase {
   @Getter
   Credentials credentials;
 
+  @SneakyThrows
   @Override
-  protected void setUp() throws Exception {
-    super.setUp();
+  public void setUp() {
 
     String keyVar = System.getenv(KEY_ENV_VAR);
     if (keyVar == null) {
@@ -64,9 +65,9 @@ public class CloudStorageIntegrationTestCase extends TestCase {
     storage.create(BucketInfo.of(bucket));
   }
 
+  @SneakyThrows
   @Override
-  protected void tearDown() throws Exception {
-    super.tearDown();
+  public void tearDown() {
     RemoteStorageHelper.forceDelete(storage, bucket, 5, TimeUnit.SECONDS);
   }
 }

--- a/java/src/test/java/com/google/appengine/tools/mapreduce/CloudStorageIntegrationTestHelper.java
+++ b/java/src/test/java/com/google/appengine/tools/mapreduce/CloudStorageIntegrationTestHelper.java
@@ -46,6 +46,9 @@ public class CloudStorageIntegrationTestHelper implements LocalServiceTestConfig
   @Getter
   Credentials credentials;
 
+  @Getter
+  String base64EncodedServiceAccountKey;
+
   @SneakyThrows
   @Override
   public void setUp() {
@@ -54,8 +57,8 @@ public class CloudStorageIntegrationTestHelper implements LocalServiceTestConfig
     if (keyVar == null) {
       throw new IllegalStateException("Must set environment variable " + KEY_ENV_VAR + " as base64 encoded service account key to use for storage integration tests");
     }
-    keyVar = keyVar.trim();
-    String jsonKey = new String(Base64.getDecoder().decode(keyVar.getBytes()));
+    base64EncodedServiceAccountKey = keyVar.trim();
+    String jsonKey = new String(Base64.getDecoder().decode(base64EncodedServiceAccountKey.getBytes()));
 
     credentials = ServiceAccountCredentials.fromStream(new ByteArrayInputStream(jsonKey.getBytes()));
     projectId = ((ServiceAccountCredentials) credentials).getProjectId();

--- a/java/src/test/java/com/google/appengine/tools/mapreduce/CustomOutputTest.java
+++ b/java/src/test/java/com/google/appengine/tools/mapreduce/CustomOutputTest.java
@@ -87,7 +87,9 @@ public class CustomOutputTest extends EndToEndTestCase {
         .setOutput(new CustomOutput())
         .setNumReducers(17);
     PipelineService pipelineService = PipelineServiceFactory.newPipelineService();
-    MapReduceSettings mrSettings = new MapReduceSettings.Builder().build();
+    MapReduceSettings mrSettings = new MapReduceSettings.Builder()
+      .setStorageCredentials(getStorageTestHelper().getCredentials())
+      .build();
     String jobId = pipelineService.startNewPipeline(
         new MapReduceJob<>(mrSpecBuilder.build(), mrSettings));
     assertFalse(jobId.isEmpty());

--- a/java/src/test/java/com/google/appengine/tools/mapreduce/CustomOutputTest.java
+++ b/java/src/test/java/com/google/appengine/tools/mapreduce/CustomOutputTest.java
@@ -88,7 +88,7 @@ public class CustomOutputTest extends EndToEndTestCase {
         .setNumReducers(17);
     PipelineService pipelineService = PipelineServiceFactory.newPipelineService();
     MapReduceSettings mrSettings = new MapReduceSettings.Builder()
-      .setStorageCredentials(getStorageTestHelper().getCredentials())
+      .setServiceAccountKey(getStorageTestHelper().getBase64EncodedServiceAccountKey())
       .build();
     String jobId = pipelineService.startNewPipeline(
         new MapReduceJob<>(mrSpecBuilder.build(), mrSettings));

--- a/java/src/test/java/com/google/appengine/tools/mapreduce/EndToEndTest.java
+++ b/java/src/test/java/com/google/appengine/tools/mapreduce/EndToEndTest.java
@@ -50,11 +50,11 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 
-import com.sun.scenario.Settings;
 import lombok.RequiredArgsConstructor;
 import org.easymock.EasyMock;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.BlockJUnit4ClassRunner;
@@ -89,29 +89,27 @@ public class EndToEndTest extends EndToEndTestCase {
 
   private PipelineService pipelineService;
 
-  CloudStorageIntegrationTestHelper storageIntegrationTestHelper = new CloudStorageIntegrationTestHelper();
 
   GoogleCloudStorageFileOutput.Options cloudStorageFileOutputOptions;
   MapReduceSettings testSettings;
+
+  @BeforeClass
+  public void storageSetup() {
+
+  }
 
   @Before
   @Override
   public void setUp() throws Exception {
     super.setUp();
     pipelineService = PipelineServiceFactory.newPipelineService();
-    storageIntegrationTestHelper.setUp();
     cloudStorageFileOutputOptions = GoogleCloudStorageFileOutput.BaseOptions.defaults()
-      .withCredentials(storageIntegrationTestHelper.getCredentials())
-      .withProjectId(storageIntegrationTestHelper.getProjectId()); //prob not really needed ..
+      .withCredentials(getStorageTestHelper().getCredentials())
+      .withProjectId(getStorageTestHelper().getProjectId()); //prob not really needed ..
     testSettings = new MapReduceSettings.Builder()
       .setStorageCredentials(getStorageTestHelper().getCredentials())
       .setBucketName(getStorageTestHelper().getBucket())
       .build();
-  }
-
-  @After
-  public void tearDown() {
-    storageIntegrationTestHelper.tearDown();
   }
 
   private interface Verifier<R> {

--- a/java/src/test/java/com/google/appengine/tools/mapreduce/EndToEndTest.java
+++ b/java/src/test/java/com/google/appengine/tools/mapreduce/EndToEndTest.java
@@ -50,6 +50,7 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 
+import com.sun.scenario.Settings;
 import lombok.RequiredArgsConstructor;
 import org.easymock.EasyMock;
 import org.junit.After;
@@ -91,6 +92,7 @@ public class EndToEndTest extends EndToEndTestCase {
   CloudStorageIntegrationTestHelper storageIntegrationTestHelper = new CloudStorageIntegrationTestHelper();
 
   GoogleCloudStorageFileOutput.Options cloudStorageFileOutputOptions;
+  MapReduceSettings testSettings;
 
   @Before
   @Override
@@ -101,7 +103,10 @@ public class EndToEndTest extends EndToEndTestCase {
     cloudStorageFileOutputOptions = GoogleCloudStorageFileOutput.BaseOptions.defaults()
       .withCredentials(storageIntegrationTestHelper.getCredentials())
       .withProjectId(storageIntegrationTestHelper.getProjectId()); //prob not really needed ..
-
+    testSettings = new MapReduceSettings.Builder()
+      .setStorageCredentials(getStorageTestHelper().getCredentials())
+      .setBucketName(getStorageTestHelper().getBucket())
+      .build();
   }
 
   @After
@@ -135,10 +140,7 @@ public class EndToEndTest extends EndToEndTestCase {
 
   private <I, K, V, O, R> void runTest(MapReduceSpecification<I, K, V, O, R> mrSpec,
       Verifier<R> verifier) throws Exception {
-    runTest(new MapReduceSettings.Builder()
-      .setStorageCredentials(getStorageTestHelper().getCredentials())
-      .setBucketName(getStorageTestHelper().getBucket())
-      .build(), mrSpec, verifier);
+    runTest(testSettings, mrSpec, verifier);
   }
 
   private <I, K, V, O, R> void runTest(MapReduceSettings settings,
@@ -372,8 +374,8 @@ public class EndToEndTest extends EndToEndTestCase {
         assertEquals(50000, allOutput.size());
       }
     };
-    runTest(new MapReduceSettings.Builder().setMapFanout(5).build(), spec, verifier);
-    runTest(new MapReduceSettings.Builder().setMapFanout(2).build(), spec, verifier);
+    runTest(new MapReduceSettings.Builder(testSettings).setMapFanout(5).build(), spec, verifier);
+    runTest(new MapReduceSettings.Builder(testSettings).setMapFanout(2).build(), spec, verifier);
   }
 
   @Test

--- a/java/src/test/java/com/google/appengine/tools/mapreduce/EndToEndTest.java
+++ b/java/src/test/java/com/google/appengine/tools/mapreduce/EndToEndTest.java
@@ -135,7 +135,9 @@ public class EndToEndTest extends EndToEndTestCase {
 
   private <I, K, V, O, R> void runTest(MapReduceSpecification<I, K, V, O, R> mrSpec,
       Verifier<R> verifier) throws Exception {
-    runTest(new MapReduceSettings.Builder().build(), mrSpec, verifier);
+    runTest(new MapReduceSettings.Builder()
+      .setStorageCredentials(getStorageTestHelper().getCredentials())
+      .build(), mrSpec, verifier);
   }
 
   private <I, K, V, O, R> void runTest(MapReduceSettings settings,

--- a/java/src/test/java/com/google/appengine/tools/mapreduce/EndToEndTest.java
+++ b/java/src/test/java/com/google/appengine/tools/mapreduce/EndToEndTest.java
@@ -1190,7 +1190,7 @@ public class EndToEndTest extends EndToEndTestCase {
     @Override
     public void beginSlice() {
       GcsFilename filename = new GcsFilename("bucket", UUID.randomUUID().toString());
-      sideOutput = new GoogleCloudStorageFileOutputWriter(filename, "application/octet-stream");
+      sideOutput = new GoogleCloudStorageFileOutputWriter(filename, "application/octet-stream", GoogleCloudStorageFileOutputWriter.BaseOptions.defaults());
       try {
         sideOutput.beginShard();
         sideOutput.beginSlice();

--- a/java/src/test/java/com/google/appengine/tools/mapreduce/EndToEndTest.java
+++ b/java/src/test/java/com/google/appengine/tools/mapreduce/EndToEndTest.java
@@ -98,10 +98,10 @@ public class EndToEndTest extends EndToEndTestCase {
     super.setUp();
     pipelineService = PipelineServiceFactory.newPipelineService();
     cloudStorageFileOutputOptions = GoogleCloudStorageFileOutput.BaseOptions.defaults()
-      .withCredentials(getStorageTestHelper().getCredentials())
+      .withServiceAccountKey(getStorageTestHelper().getBase64EncodedServiceAccountKey())
       .withProjectId(getStorageTestHelper().getProjectId()); //prob not really needed ..
     testSettings = new MapReduceSettings.Builder()
-      .setStorageCredentials(getStorageTestHelper().getCredentials())
+      .setServiceAccountKey(getStorageTestHelper().getBase64EncodedServiceAccountKey())
       .setBucketName(getStorageTestHelper().getBucket())
       .build();
   }

--- a/java/src/test/java/com/google/appengine/tools/mapreduce/EndToEndTest.java
+++ b/java/src/test/java/com/google/appengine/tools/mapreduce/EndToEndTest.java
@@ -1191,11 +1191,12 @@ public class EndToEndTest extends EndToEndTestCase {
   static class SideOutputMapper extends Mapper<Long, GcsFilename, Void> {
     transient GoogleCloudStorageFileOutputWriter sideOutput;
 
+    final String bucket;
     final GoogleCloudStorageFileOutput.Options options;
 
     @Override
     public void beginSlice() {
-      GcsFilename filename = new GcsFilename("bucket", UUID.randomUUID().toString());
+      GcsFilename filename = new GcsFilename(bucket, UUID.randomUUID().toString());
       sideOutput = new GoogleCloudStorageFileOutputWriter(filename, "application/octet-stream", options);
       try {
         sideOutput.beginShard();
@@ -1232,7 +1233,7 @@ public class EndToEndTest extends EndToEndTestCase {
   public void testSideOutput() throws Exception {
 
     runTest(new MapReduceSpecification.Builder<>(new ConsecutiveLongInput(0, 6, 6),
-        new SideOutputMapper(cloudStorageFileOutputOptions), KeyProjectionReducer.<GcsFilename, Void>create(),
+        new SideOutputMapper(getStorageTestHelper().getBucket(), cloudStorageFileOutputOptions), KeyProjectionReducer.<GcsFilename, Void>create(),
         new InMemoryOutput<GcsFilename>())
         .setKeyMarshaller(Marshallers.<GcsFilename>getSerializationMarshaller())
         .setValueMarshaller(Marshallers.getVoidMarshaller())

--- a/java/src/test/java/com/google/appengine/tools/mapreduce/EndToEndTest.java
+++ b/java/src/test/java/com/google/appengine/tools/mapreduce/EndToEndTest.java
@@ -320,13 +320,13 @@ public class EndToEndTest extends EndToEndTestCase {
 
   @Test
   public void testSomeShardsEmpty() throws Exception {
-    runTest(new MapReduceSpecification.Builder<>(new ConsecutiveLongInput(0, 5, 10),
+    runTest(new MapReduceSpecification.Builder<>(new ConsecutiveLongInput(0, 5, 3),
         new Mod37Mapper(), ValueProjectionReducer.<String, Long>create(),
         new InMemoryOutput<Long>())
         .setKeyMarshaller(Marshallers.getStringMarshaller())
         .setValueMarshaller(Marshallers.getLongMarshaller())
         .setJobName("Empty test MR")
-        .setNumReducers(10)
+        .setNumReducers(2)
         .build(), new Verifier<List<List<Long>>>() {
       @Override
       public void verify(MapReduceResult<List<List<Long>>> result) throws Exception {
@@ -347,11 +347,11 @@ public class EndToEndTest extends EndToEndTestCase {
     MapReduceSpecification<Long, String, Long, Long, List<List<Long>>> spec =
         new MapReduceSpecification.Builder<>(new ConsecutiveLongInput(0, 50000, 10),
             new Mod37Mapper(), ValueProjectionReducer.<String, Long>create(),
-            new InMemoryOutput<Long>())
+            new InMemoryOutput<>())
             .setKeyMarshaller(Marshallers.getStringMarshaller())
             .setValueMarshaller(Marshallers.getLongMarshaller())
             .setJobName("Empty test MR")
-            .setNumReducers(10)
+            .setNumReducers(2)
             .build();
     Verifier<List<List<Long>>> verifier = new Verifier<List<List<Long>>>() {
       @Override
@@ -388,7 +388,7 @@ public class EndToEndTest extends EndToEndTestCase {
 
   @Test
   public void testDoNothing() throws Exception {
-    runTest(new MapReduceSpecification.Builder<>(new NoInput<Long>(1), new Mod37Mapper(),
+    runTest(new MapReduceSpecification.Builder<>(new NoInput<>(1), new Mod37Mapper(),
         NoReducer.<String, Long, String>create(), new NoOutput<String, String>())
         .setKeyMarshaller(Marshallers.getStringMarshaller())
         .setValueMarshaller(Marshallers.getLongMarshaller()).setJobName("Empty test MR").build(),
@@ -915,13 +915,14 @@ public class EndToEndTest extends EndToEndTestCase {
 
   @Test
   public void testDatastoreData() throws Exception {
+    final int SHARD_COUNT = 3;
     final DatastoreService datastoreService = DatastoreServiceFactory.getDatastoreService();
     // Datastore restriction: id cannot be zero.
     for (long i = 1; i <= 100; ++i) {
       datastoreService.put(new Entity(KeyFactory.createKey("Test", i)));
     }
-    runTest(new MapReduceSpecification.Builder<>(new DatastoreInput("Test", 5), new TestMapper(),
-        new TestReducer(), new InMemoryOutput<KeyValue<String, List<Long>>>())
+    runTest(new MapReduceSpecification.Builder<>(new DatastoreInput("Test", SHARD_COUNT), new TestMapper(),
+        new TestReducer(), new InMemoryOutput<>())
         .setKeyMarshaller(Marshallers.getStringMarshaller())
         .setValueMarshaller(Marshallers.getLongMarshaller()).setJobName("Test MR").build(),
         new Verifier<List<List<KeyValue<String, List<Long>>>>>() {
@@ -933,10 +934,10 @@ public class EndToEndTest extends EndToEndTestCase {
             assertNotNull(counters);
 
             assertEquals(100, counters.getCounter("map").getValue());
-            assertEquals(5, counters.getCounter("beginShard").getValue());
-            assertEquals(5, counters.getCounter("endShard").getValue());
-            assertEquals(5, counters.getCounter("beginSlice").getValue());
-            assertEquals(5, counters.getCounter("endSlice").getValue());
+            assertEquals(SHARD_COUNT, counters.getCounter("beginShard").getValue());
+            assertEquals(SHARD_COUNT, counters.getCounter("endShard").getValue());
+            assertEquals(SHARD_COUNT, counters.getCounter("beginSlice").getValue());
+            assertEquals(SHARD_COUNT, counters.getCounter("endSlice").getValue());
 
             assertEquals(100, counters.getCounter(CounterNames.MAPPER_CALLS).getValue());
             assertTrue(counters.getCounter(CounterNames.MAPPER_WALLTIME_MILLIS).getValue() > 0);
@@ -995,9 +996,11 @@ public class EndToEndTest extends EndToEndTestCase {
   @SuppressWarnings("serial")
   private static class Mod37Mapper extends Mapper<Long, String, Long> {
 
+    static final int MOD_VALUE = 37;
+
     @Override
     public void map(Long input) {
-      String mod37 = String.valueOf(Math.abs(input) % 37);
+      String mod37 = String.valueOf(Math.abs(input) % MOD_VALUE);
       emit(mod37, input);
     }
   }
@@ -1037,16 +1040,17 @@ public class EndToEndTest extends EndToEndTestCase {
 
   @Test
   public void testSomeNumbers() throws Exception {
+    final int SHARD_COUNT = 5;
     MapReduceSpecification.Builder<Long, String, Long, KeyValue<String, List<Long>>,
         List<List<KeyValue<String, List<Long>>>>> mrSpecBuilder =
         new MapReduceSpecification.Builder<>();
     mrSpecBuilder.setJobName("Test MR");
-    mrSpecBuilder.setInput(new ConsecutiveLongInput(-10000, 10000, 10));
+    mrSpecBuilder.setInput(new ConsecutiveLongInput(-10000, 10000, SHARD_COUNT));
     mrSpecBuilder.setMapper(new Mod37Mapper());
     mrSpecBuilder.setKeyMarshaller(Marshallers.getStringMarshaller());
     mrSpecBuilder.setValueMarshaller(Marshallers.getLongMarshaller());
     mrSpecBuilder.setReducer(new TestReducer());
-    mrSpecBuilder.setOutput(new InMemoryOutput<KeyValue<String, List<Long>>>());
+    mrSpecBuilder.setOutput(new InMemoryOutput<>());
     mrSpecBuilder.setNumReducers(5);
 
     runTest(mrSpecBuilder.build(), new Verifier<List<List<KeyValue<String, List<Long>>>>>() {
@@ -1055,20 +1059,20 @@ public class EndToEndTest extends EndToEndTestCase {
           throws Exception {
         Counters counters = result.getCounters();
         assertEquals(20000, counters.getCounter(CounterNames.MAPPER_CALLS).getValue());
-        assertEquals(37, counters.getCounter(CounterNames.REDUCER_CALLS).getValue());
+        assertEquals(Mod37Mapper.MOD_VALUE, counters.getCounter(CounterNames.REDUCER_CALLS).getValue());
 
         List<List<KeyValue<String, List<Long>>>> actualOutput = result.getOutputResult();
         List<ArrayListMultimap<String, Long>> expectedOutput = Lists.newArrayList();
-        for (int i = 0; i < 5; i++) {
+        for (int i = 0; i < SHARD_COUNT; i++) {
           expectedOutput.add(ArrayListMultimap.<String, Long>create());
         }
         Marshaller<String> marshaller = Marshallers.getStringMarshaller();
-        HashingSharder sharder = new HashingSharder(5);
+        HashingSharder sharder = new HashingSharder(SHARD_COUNT);
         for (long l = -10000; l < 10000; l++) {
-          String mod37 = String.valueOf(Math.abs(l) % 37);
+          String mod37 = String.valueOf(Math.abs(l) % Mod37Mapper.MOD_VALUE);
           expectedOutput.get(sharder.getShardForKey(marshaller.toBytes(mod37))).put(mod37, l);
         }
-        for (int i = 0; i < 5; i++) {
+        for (int i = 0; i < SHARD_COUNT; i++) {
           assertEquals(expectedOutput.get(i).keySet().size(), actualOutput.get(i).size());
           for (KeyValue<String, List<Long>> actual : actualOutput.get(i)) {
             List<Long> value = new ArrayList<>(actual.getValue());
@@ -1103,7 +1107,7 @@ public class EndToEndTest extends EndToEndTestCase {
       public void verify(MapReduceResult<List<List<String>>> result) throws Exception {
         Counters counters = result.getCounters();
         assertEquals(20000, counters.getCounter(CounterNames.MAPPER_CALLS).getValue());
-        assertEquals(37, counters.getCounter(CounterNames.REDUCER_CALLS).getValue());
+        assertEquals(Mod37Mapper.MOD_VALUE, counters.getCounter(CounterNames.REDUCER_CALLS).getValue());
 
         List<List<String>> actualOutput = result.getOutputResult();
         assertEquals(5, actualOutput.size());
@@ -1111,8 +1115,8 @@ public class EndToEndTest extends EndToEndTestCase {
         for (int shard = 0; shard < 5; shard++) {
           allKeys.addAll(actualOutput.get(shard));
         }
-        assertEquals(37, allKeys.size());
-        for (int i = 0; i < 37; i++) {
+        assertEquals(Mod37Mapper.MOD_VALUE, allKeys.size());
+        for (int i = 0; i < Mod37Mapper.MOD_VALUE; i++) {
           assertTrue(String.valueOf(i), allKeys.contains(String.valueOf(i)));
         }
       }
@@ -1154,32 +1158,35 @@ public class EndToEndTest extends EndToEndTestCase {
 
   @Test
   public void testSlicingJob() throws Exception {
+    final int NUM_SHARDS = 4;
+    final int NUM_REDUCERS = 3;
+
     MapReduceSpecification.Builder<Long, String, Long, String, List<List<String>>> builder =
         new MapReduceSpecification.Builder<>();
     builder.setJobName("Test MR");
-    builder.setInput(new ConsecutiveLongInput(-100, 100, 10));
+    builder.setInput(new ConsecutiveLongInput(-100, 100, NUM_SHARDS));
     builder.setMapper(new Mod37Mapper());
     builder.setKeyMarshaller(Marshallers.getStringMarshaller());
     builder.setValueMarshaller(Marshallers.getLongMarshaller());
     builder.setReducer(KeyProjectionReducer.<String, Long>create());
-    builder.setOutput(new InMemoryOutput<String>());
-    builder.setNumReducers(5);
+    builder.setOutput(new InMemoryOutput<>());
+    builder.setNumReducers(NUM_REDUCERS);
     runTest(new MapReduceSettings.Builder(testSettings).setMillisPerSlice(0).build(), builder.build(),
         new Verifier<List<List<String>>>() {
           @Override
           public void verify(MapReduceResult<List<List<String>>> result) throws Exception {
             Counters counters = result.getCounters();
             assertEquals(200, counters.getCounter(CounterNames.MAPPER_CALLS).getValue());
-            assertEquals(37, counters.getCounter(CounterNames.REDUCER_CALLS).getValue());
+            assertEquals(Mod37Mapper.MOD_VALUE, counters.getCounter(CounterNames.REDUCER_CALLS).getValue());
 
             List<List<String>> actualOutput = result.getOutputResult();
-            assertEquals(5, actualOutput.size());
+            assertEquals(NUM_REDUCERS, actualOutput.size());
             List<String> allKeys = new ArrayList<>();
-            for (int shard = 0; shard < 5; shard++) {
-              allKeys.addAll(actualOutput.get(shard));
+            for (int reducerShard = 0; reducerShard < NUM_REDUCERS; reducerShard++) {
+              allKeys.addAll(actualOutput.get(reducerShard));
             }
-            assertEquals(37, allKeys.size());
-            for (int i = 0; i < 37; i++) {
+            assertEquals(Mod37Mapper.MOD_VALUE, allKeys.size());
+            for (int i = 0; i < Mod37Mapper.MOD_VALUE; i++) {
               assertTrue(String.valueOf(i), allKeys.contains(String.valueOf(i)));
             }
           }
@@ -1232,9 +1239,11 @@ public class EndToEndTest extends EndToEndTestCase {
   @Test
   public void testSideOutput() throws Exception {
 
-    runTest(new MapReduceSpecification.Builder<>(new ConsecutiveLongInput(0, 6, 6),
+    final int SHARD_COUNT = 3;
+
+    runTest(new MapReduceSpecification.Builder<>(new ConsecutiveLongInput(0, SHARD_COUNT, SHARD_COUNT),
         new SideOutputMapper(getStorageTestHelper().getBucket(), cloudStorageFileOutputOptions), KeyProjectionReducer.<GcsFilename, Void>create(),
-        new InMemoryOutput<GcsFilename>())
+        new InMemoryOutput<>())
         .setKeyMarshaller(Marshallers.<GcsFilename>getSerializationMarshaller())
         .setValueMarshaller(Marshallers.getVoidMarshaller())
         .setJobName("Test MR")
@@ -1244,13 +1253,13 @@ public class EndToEndTest extends EndToEndTestCase {
           public void verify(MapReduceResult<List<List<GcsFilename>>> result) throws Exception {
             List<List<GcsFilename>> outputResult = result.getOutputResult();
             Set<Long> expected = new HashSet<>();
-            for (long i = 0; i < 6; i++) {
+            for (long i = 0; i < SHARD_COUNT; i++) {
               expected.add(i);
             }
             assertEquals(1, outputResult.size());
 
             for (List<GcsFilename> files : outputResult) {
-              assertEquals(6, files.size());
+              assertEquals(SHARD_COUNT, files.size());
               for (GcsFilename file : files) {
                 ByteBuffer buf = ByteBuffer.allocate(8);
                 try (ReadChannel ch = getStorageTestHelper().getStorage().reader(file.asBlobId())) {

--- a/java/src/test/java/com/google/appengine/tools/mapreduce/EndToEndTest.java
+++ b/java/src/test/java/com/google/appengine/tools/mapreduce/EndToEndTest.java
@@ -137,6 +137,7 @@ public class EndToEndTest extends EndToEndTestCase {
       Verifier<R> verifier) throws Exception {
     runTest(new MapReduceSettings.Builder()
       .setStorageCredentials(getStorageTestHelper().getCredentials())
+      .setBucketName(getStorageTestHelper().getBucket())
       .build(), mrSpec, verifier);
   }
 

--- a/java/src/test/java/com/google/appengine/tools/mapreduce/EndToEndTestCase.java
+++ b/java/src/test/java/com/google/appengine/tools/mapreduce/EndToEndTestCase.java
@@ -64,13 +64,8 @@ public abstract class EndToEndTestCase {
   }
 
   @Getter
-  private static CloudStorageIntegrationTestHelper storageTestHelper;
+  private CloudStorageIntegrationTestHelper storageTestHelper;
 
-  @BeforeClass
-  static public void setupStorage() {
-    storageTestHelper = new CloudStorageIntegrationTestHelper();
-    storageTestHelper.setUp();
-  }
   @Before
   public void setUp() throws Exception {
     helper.setUp();
@@ -82,16 +77,13 @@ public abstract class EndToEndTestCase {
     ApiProxyLocal proxy = (ApiProxyLocal) ApiProxy.getDelegate();
     // Creating files is not allowed in some test execution environments, so don't.
     proxy.setProperty(LocalBlobstoreService.NO_STORAGE_PROPERTY, "true");
+    storageTestHelper = new CloudStorageIntegrationTestHelper();
     storageTestHelper.setUp();
   }
 
   @After
   public void tearDown() throws Exception {
     helper.tearDown();
-  }
-
-  @AfterClass
-  public static void tearDownStorage() {
     storageTestHelper.tearDown();
   }
 

--- a/java/src/test/java/com/google/appengine/tools/mapreduce/EndToEndTestCase.java
+++ b/java/src/test/java/com/google/appengine/tools/mapreduce/EndToEndTestCase.java
@@ -23,6 +23,7 @@ import com.google.appengine.tools.pipeline.impl.servlets.TaskHandler;
 import com.google.apphosting.api.ApiProxy;
 import com.google.common.base.CharMatcher;
 
+import lombok.Getter;
 import org.junit.After;
 import org.junit.Before;
 
@@ -60,6 +61,9 @@ public abstract class EndToEndTestCase {
     return null;
   }
 
+  @Getter
+  private CloudStorageIntegrationTestHelper storageTestHelper = new CloudStorageIntegrationTestHelper();
+
   @Before
   public void setUp() throws Exception {
     helper.setUp();
@@ -71,11 +75,13 @@ public abstract class EndToEndTestCase {
     ApiProxyLocal proxy = (ApiProxyLocal) ApiProxy.getDelegate();
     // Creating files is not allowed in some test execution environments, so don't.
     proxy.setProperty(LocalBlobstoreService.NO_STORAGE_PROPERTY, "true");
+    storageTestHelper.setUp();
   }
 
   @After
   public void tearDown() throws Exception {
     helper.tearDown();
+    storageTestHelper.tearDown();
   }
 
   protected List<QueueStateInfo.TaskStateInfo> getTasks() {

--- a/java/src/test/java/com/google/appengine/tools/mapreduce/EndToEndTestCase.java
+++ b/java/src/test/java/com/google/appengine/tools/mapreduce/EndToEndTestCase.java
@@ -25,7 +25,9 @@ import com.google.common.base.CharMatcher;
 
 import lombok.Getter;
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 
 import java.io.ByteArrayInputStream;
 import java.io.ObjectInputStream;
@@ -62,8 +64,13 @@ public abstract class EndToEndTestCase {
   }
 
   @Getter
-  private CloudStorageIntegrationTestHelper storageTestHelper = new CloudStorageIntegrationTestHelper();
+  private CloudStorageIntegrationTestHelper storageTestHelper;
 
+  @BeforeClass
+  public void setupStorage() {
+    storageTestHelper = new CloudStorageIntegrationTestHelper();
+    storageTestHelper.setUp();
+  }
   @Before
   public void setUp() throws Exception {
     helper.setUp();
@@ -81,6 +88,10 @@ public abstract class EndToEndTestCase {
   @After
   public void tearDown() throws Exception {
     helper.tearDown();
+  }
+
+  @AfterClass
+  public void tearDownStorage() {
     storageTestHelper.tearDown();
   }
 

--- a/java/src/test/java/com/google/appengine/tools/mapreduce/EndToEndTestCase.java
+++ b/java/src/test/java/com/google/appengine/tools/mapreduce/EndToEndTestCase.java
@@ -64,10 +64,10 @@ public abstract class EndToEndTestCase {
   }
 
   @Getter
-  private CloudStorageIntegrationTestHelper storageTestHelper;
+  private static CloudStorageIntegrationTestHelper storageTestHelper;
 
   @BeforeClass
-  public void setupStorage() {
+  static public void setupStorage() {
     storageTestHelper = new CloudStorageIntegrationTestHelper();
     storageTestHelper.setUp();
   }
@@ -91,7 +91,7 @@ public abstract class EndToEndTestCase {
   }
 
   @AfterClass
-  public void tearDownStorage() {
+  public static void tearDownStorage() {
     storageTestHelper.tearDown();
   }
 

--- a/java/src/test/java/com/google/appengine/tools/mapreduce/impl/FilesByShardTest.java
+++ b/java/src/test/java/com/google/appengine/tools/mapreduce/impl/FilesByShardTest.java
@@ -1,6 +1,6 @@
 package com.google.appengine.tools.mapreduce.impl;
 
-import com.google.appengine.tools.cloudstorage.GcsFilename;
+import com.google.appengine.tools.mapreduce.GcsFilename;
 import com.google.appengine.tools.mapreduce.GoogleCloudStorageFileSet;
 
 import junit.framework.TestCase;

--- a/java/src/test/java/com/google/appengine/tools/mapreduce/impl/GoogleCloudStorageMapOutputTest.java
+++ b/java/src/test/java/com/google/appengine/tools/mapreduce/impl/GoogleCloudStorageMapOutputTest.java
@@ -108,9 +108,11 @@ public class GoogleCloudStorageMapOutputTest extends TestCase {
   }
 
   private void writeAndVerifyContent(SliceData... sliceData) throws IOException  {
-    GoogleCloudStorageFileOutput.BaseOptions outputOptions = GoogleCloudStorageFileOutput.BaseOptions.builder().credentials(cloudStorageIntegrationTestHelper.getCredentials()).projectId(cloudStorageIntegrationTestHelper.getProjectId()).build();
+    GoogleCloudStorageFileOutput.BaseOptions outputOptions = GoogleCloudStorageFileOutput.BaseOptions.builder()
+      .serviceAccountKey(cloudStorageIntegrationTestHelper.getBase64EncodedServiceAccountKey())
+      .projectId(cloudStorageIntegrationTestHelper.getProjectId()).build();
     GoogleCloudStorageLineInput.BaseOptions inputOptions = GoogleCloudStorageLineInput.BaseOptions.builder()
-      .credentials(cloudStorageIntegrationTestHelper.getCredentials())
+      .serviceAccountKey(cloudStorageIntegrationTestHelper.getBase64EncodedServiceAccountKey())
       .build();
 
     GoogleCloudStorageMapOutput<Long, String> output = new GoogleCloudStorageMapOutput<>(cloudStorageIntegrationTestHelper.getBucket(),

--- a/java/src/test/java/com/google/appengine/tools/mapreduce/impl/GoogleCloudStorageMapOutputTest.java
+++ b/java/src/test/java/com/google/appengine/tools/mapreduce/impl/GoogleCloudStorageMapOutputTest.java
@@ -2,13 +2,10 @@
 package com.google.appengine.tools.mapreduce.impl;
 
 import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
-import com.google.appengine.tools.mapreduce.InputReader;
-import com.google.appengine.tools.mapreduce.KeyValue;
-import com.google.appengine.tools.mapreduce.Marshaller;
-import com.google.appengine.tools.mapreduce.Marshallers;
-import com.google.appengine.tools.mapreduce.OutputWriter;
-import com.google.appengine.tools.mapreduce.Sharder;
+import com.google.appengine.tools.mapreduce.*;
 
+import com.google.appengine.tools.mapreduce.inputs.GoogleCloudStorageLineInput;
+import com.google.appengine.tools.mapreduce.outputs.GoogleCloudStorageFileOutput;
 import junit.framework.TestCase;
 
 import java.io.IOException;
@@ -27,7 +24,6 @@ import java.util.Random;
  */
 public class GoogleCloudStorageMapOutputTest extends TestCase {
 
-  private static final String BUCKET = "GoogleCloudStorageMapOutputTest";
   private static final String JOB = "JOB1";
   private static final Marshaller<Long> KEY_MARSHALLER = Marshallers.getLongMarshaller();
   private static final Marshaller<String> VALUE_MARSHALLER = Marshallers.getStringMarshaller();
@@ -38,17 +34,20 @@ public class GoogleCloudStorageMapOutputTest extends TestCase {
   private static final Random RND = new SecureRandom();
 
   private final LocalServiceTestHelper helper = new LocalServiceTestHelper();
+  private final CloudStorageIntegrationTestHelper cloudStorageIntegrationTestHelper = new CloudStorageIntegrationTestHelper();
 
   @Override
   public void setUp() {
     helper.setUp();
     System.setProperty(COMPONENTS_PER_COMPOSE_PROPERTY, String.valueOf(COMPONENTS_PER_COMPOSE));
+    cloudStorageIntegrationTestHelper.setUp();
   }
 
   @Override
   public void tearDown() {
     helper.tearDown();
     System.clearProperty(COMPONENTS_PER_COMPOSE_PROPERTY);
+    cloudStorageIntegrationTestHelper.tearDown();
   }
 
   public void testNoContent() throws IOException {
@@ -109,7 +108,12 @@ public class GoogleCloudStorageMapOutputTest extends TestCase {
   }
 
   private void writeAndVerifyContent(SliceData... sliceData) throws IOException  {
-    GoogleCloudStorageMapOutput<Long, String> output = new GoogleCloudStorageMapOutput<>(BUCKET,
+    GoogleCloudStorageFileOutput.BaseOptions outputOptions = GoogleCloudStorageFileOutput.BaseOptions.builder().credentials(cloudStorageIntegrationTestHelper.getCredentials()).projectId(cloudStorageIntegrationTestHelper.getProjectId()).build();
+    GoogleCloudStorageLineInput.BaseOptions inputOptions = GoogleCloudStorageLineInput.BaseOptions.builder()
+      .credentials(cloudStorageIntegrationTestHelper.getCredentials())
+      .build();
+
+    GoogleCloudStorageMapOutput<Long, String> output = new GoogleCloudStorageMapOutput<>(cloudStorageIntegrationTestHelper.getBucket(),
         JOB, KEY_MARSHALLER, VALUE_MARSHALLER, new Sharder() {
           private static final long serialVersionUID = 1L;
 
@@ -122,7 +126,7 @@ public class GoogleCloudStorageMapOutputTest extends TestCase {
           public int getShardForKey(ByteBuffer key) {
             return 0;
           }
-        });
+        }, outputOptions);
     List<? extends OutputWriter<KeyValue<Long, String>>> writers = output.createWriters(1);
     assertEquals(1, writers.size());
     List<KeyValue<Long, String>> values = new ArrayList<>();
@@ -148,7 +152,7 @@ public class GoogleCloudStorageMapOutputTest extends TestCase {
     FilesByShard filesByShard = output.finish(writers);
     assertEquals(1, filesByShard.getShardCount());
     List<? extends InputReader<KeyValue<ByteBuffer, ByteBuffer>>> input =
-        new GoogleCloudStorageSortInput(filesByShard).createReaders();
+        new GoogleCloudStorageSortInput(filesByShard, inputOptions).createReaders();
     assertEquals(1, input.size());
     int expectedFiles = (int) Math.ceil((double) sliceCount / COMPONENTS_PER_COMPOSE);
     assertEquals(expectedFiles, filesByShard.getFilesForShard(0).getNumFiles());

--- a/java/src/test/java/com/google/appengine/tools/mapreduce/inputs/GoogleCloudStorageLevelDbInputReaderTest.java
+++ b/java/src/test/java/com/google/appengine/tools/mapreduce/inputs/GoogleCloudStorageLevelDbInputReaderTest.java
@@ -59,7 +59,7 @@ public class GoogleCloudStorageLevelDbInputReaderTest extends TestCase {
 
   GoogleCloudStorageLineInput.Options inputOptions() {
     return GoogleCloudStorageLineInput.BaseOptions.builder()
-      .credentials(storageHelper.getCredentials())
+      .serviceAccountKey(storageHelper.getBase64EncodedServiceAccountKey())
       .bufferSize(BLOCK_SIZE * 2)
     .build();
   }
@@ -99,7 +99,7 @@ public class GoogleCloudStorageLevelDbInputReaderTest extends TestCase {
 
   public void writeData(GcsFilename filename, ByteBufferGenerator gen) throws IOException {
     LevelDbOutputWriter writer = new GoogleCloudStorageLevelDbOutputWriter(
-        new GoogleCloudStorageFileOutputWriter(filename, "text/plain", GoogleCloudStorageFileOutput.BaseOptions.defaults().withCredentials(storageHelper.getCredentials())));
+        new GoogleCloudStorageFileOutputWriter(filename, "", GoogleCloudStorageFileOutput.BaseOptions.defaults().withServiceAccountKey(storageHelper.getBase64EncodedServiceAccountKey())));
     writer.beginShard();
     writer.beginSlice();
     while (gen.hasNext()) {

--- a/java/src/test/java/com/google/appengine/tools/mapreduce/inputs/GoogleCloudStorageLevelDbInputReaderTest.java
+++ b/java/src/test/java/com/google/appengine/tools/mapreduce/inputs/GoogleCloudStorageLevelDbInputReaderTest.java
@@ -32,7 +32,7 @@ public class GoogleCloudStorageLevelDbInputReaderTest extends TestCase {
   private static final int BLOCK_SIZE = LevelDbConstants.BLOCK_SIZE;
   GcsFilename filename;
 
-  private static final CloudStorageIntegrationTestHelper storageHelper = new CloudStorageIntegrationTestHelper();
+  private CloudStorageIntegrationTestHelper storageHelper;
 
   private final LocalServiceTestHelper helper = new LocalServiceTestHelper(
       new LocalTaskQueueTestConfig(),
@@ -44,6 +44,7 @@ public class GoogleCloudStorageLevelDbInputReaderTest extends TestCase {
   public void setUp() throws Exception {
     super.setUp();
     helper.setUp();
+    storageHelper = new CloudStorageIntegrationTestHelper();
     storageHelper.setUp();
     filename = new GcsFilename(storageHelper.getBucket(), "GoogleCloudStorageLevelDbInputReaderTest");
   }

--- a/java/src/test/java/com/google/appengine/tools/mapreduce/inputs/GoogleCloudStorageLevelDbInputReaderTest.java
+++ b/java/src/test/java/com/google/appengine/tools/mapreduce/inputs/GoogleCloudStorageLevelDbInputReaderTest.java
@@ -86,7 +86,7 @@ public class GoogleCloudStorageLevelDbInputReaderTest extends TestCase {
 
   public void writeData(GcsFilename filename, ByteBufferGenerator gen) throws IOException {
     LevelDbOutputWriter writer = new GoogleCloudStorageLevelDbOutputWriter(
-        new GoogleCloudStorageFileOutputWriter(filename, "TestData"));
+        new GoogleCloudStorageFileOutputWriter(filename, "TestData", GoogleCloudStorageFileOutputWriter.BaseOptions.defaults()));
     writer.beginShard();
     writer.beginSlice();
     while (gen.hasNext()) {

--- a/java/src/test/java/com/google/appengine/tools/mapreduce/inputs/GoogleCloudStorageLevelDbInputReaderTest.java
+++ b/java/src/test/java/com/google/appengine/tools/mapreduce/inputs/GoogleCloudStorageLevelDbInputReaderTest.java
@@ -7,6 +7,7 @@ import com.google.appengine.tools.mapreduce.CloudStorageIntegrationTestHelper;
 import com.google.appengine.tools.mapreduce.GcsFilename;
 import com.google.appengine.tools.mapreduce.impl.util.LevelDbConstants;
 import com.google.appengine.tools.mapreduce.impl.util.SerializationUtil;
+import com.google.appengine.tools.mapreduce.outputs.GoogleCloudStorageFileOutput;
 import com.google.appengine.tools.mapreduce.outputs.GoogleCloudStorageFileOutputWriter;
 import com.google.appengine.tools.mapreduce.outputs.GoogleCloudStorageLevelDbOutputWriter;
 import com.google.appengine.tools.mapreduce.outputs.LevelDbOutputWriter;
@@ -86,7 +87,7 @@ public class GoogleCloudStorageLevelDbInputReaderTest extends TestCase {
 
   public void writeData(GcsFilename filename, ByteBufferGenerator gen) throws IOException {
     LevelDbOutputWriter writer = new GoogleCloudStorageLevelDbOutputWriter(
-        new GoogleCloudStorageFileOutputWriter(filename, "TestData", GoogleCloudStorageFileOutputWriter.BaseOptions.defaults()));
+        new GoogleCloudStorageFileOutputWriter(filename, "TestData", GoogleCloudStorageFileOutput.BaseOptions.defaults()));
     writer.beginShard();
     writer.beginSlice();
     while (gen.hasNext()) {

--- a/java/src/test/java/com/google/appengine/tools/mapreduce/inputs/GoogleCloudStorageLevelDbInputReaderTest.java
+++ b/java/src/test/java/com/google/appengine/tools/mapreduce/inputs/GoogleCloudStorageLevelDbInputReaderTest.java
@@ -42,6 +42,7 @@ public class GoogleCloudStorageLevelDbInputReaderTest extends TestCase {
   @Override
   @Before
   public void setUp() throws Exception {
+    super.setUp();
     helper.setUp();
     storageHelper.setUp();
     filename = new GcsFilename(storageHelper.getBucket(), "GoogleCloudStorageLevelDbInputReaderTest");

--- a/java/src/test/java/com/google/appengine/tools/mapreduce/inputs/GoogleCloudStorageLevelDbInputReaderTest.java
+++ b/java/src/test/java/com/google/appengine/tools/mapreduce/inputs/GoogleCloudStorageLevelDbInputReaderTest.java
@@ -1,11 +1,10 @@
 package com.google.appengine.tools.mapreduce.inputs;
 
-import com.google.appengine.tools.cloudstorage.GcsFilename;
-import com.google.appengine.tools.cloudstorage.GcsServiceFactory;
-import com.google.appengine.tools.development.testing.LocalBlobstoreServiceTestConfig;
 import com.google.appengine.tools.development.testing.LocalDatastoreServiceTestConfig;
 import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
 import com.google.appengine.tools.development.testing.LocalTaskQueueTestConfig;
+import com.google.appengine.tools.mapreduce.CloudStorageIntegrationTestHelper;
+import com.google.appengine.tools.mapreduce.GcsFilename;
 import com.google.appengine.tools.mapreduce.impl.util.LevelDbConstants;
 import com.google.appengine.tools.mapreduce.impl.util.SerializationUtil;
 import com.google.appengine.tools.mapreduce.outputs.GoogleCloudStorageFileOutputWriter;
@@ -32,9 +31,10 @@ public class GoogleCloudStorageLevelDbInputReaderTest extends TestCase {
   private static final int BLOCK_SIZE = LevelDbConstants.BLOCK_SIZE;
   GcsFilename filename = new GcsFilename("Bucket", "GoogleCloudStorageLevelDbInputReaderTest");
 
+  private static final CloudStorageIntegrationTestHelper storageHelper = new CloudStorageIntegrationTestHelper();
+
   private final LocalServiceTestHelper helper = new LocalServiceTestHelper(
       new LocalTaskQueueTestConfig(),
-      new LocalBlobstoreServiceTestConfig(),
       new LocalDatastoreServiceTestConfig());
 
 
@@ -47,7 +47,7 @@ public class GoogleCloudStorageLevelDbInputReaderTest extends TestCase {
   @Override
   @After
   public void tearDown() throws Exception {
-    GcsServiceFactory.createGcsService().delete(filename);
+    storageHelper.getStorage().delete(filename.asBlobId());
     helper.tearDown();
   }
 

--- a/java/src/test/java/com/google/appengine/tools/mapreduce/inputs/GoogleCloudStorageLineInputReaderTest.java
+++ b/java/src/test/java/com/google/appengine/tools/mapreduce/inputs/GoogleCloudStorageLineInputReaderTest.java
@@ -1,5 +1,6 @@
 package com.google.appengine.tools.mapreduce.inputs;
 
+import com.google.appengine.tools.mapreduce.CloudStorageIntegrationTestHelper;
 import com.google.appengine.tools.mapreduce.GcsFilename;
 import com.google.appengine.tools.mapreduce.impl.util.SerializationUtil;
 
@@ -18,35 +19,38 @@ public class GoogleCloudStorageLineInputReaderTest extends GoogleCloudStorageLin
 
   GcsFilename filename;
   long fileSize;
+  GoogleCloudStorageLineInput.BaseOptions inputOptions;
 
   @Override
   public void setUp() throws Exception {
     super.setUp();
     filename = new GcsFilename(cloudStorageIntegrationTestHelper.getBucket(), FILENAME);
     fileSize = createFile(filename.getObjectName(), RECORD, RECORDS_COUNT);
+    inputOptions = GoogleCloudStorageLineInput.BaseOptions.defaults().withCredentials(cloudStorageIntegrationTestHelper.getCredentials());
   }
+
   public void testSingleSplitPoint() throws Exception {
     List<GoogleCloudStorageLineInputReader> readers = new ArrayList<>();
-    readers.add(new GoogleCloudStorageLineInputReader(filename, 0, RECORD.length(), (byte) '\n'));
+    readers.add(new GoogleCloudStorageLineInputReader(filename, 0, RECORD.length(), (byte) '\n', inputOptions));
     readers.add(
-        new GoogleCloudStorageLineInputReader(filename, RECORD.length(), fileSize, (byte) '\n'));
+        new GoogleCloudStorageLineInputReader(filename, RECORD.length(), fileSize, (byte) '\n', inputOptions));
     verifyReaders(readers, false);
   }
 
   public void testSingleSplitPointsWithSerialization() throws Exception {
     List<GoogleCloudStorageLineInputReader> readers = new ArrayList<>();
-    readers.add(new GoogleCloudStorageLineInputReader(filename, 0, RECORD.length(), (byte) '\n'));
+    readers.add(new GoogleCloudStorageLineInputReader(filename, 0, RECORD.length(), (byte) '\n', inputOptions));
     readers.add(
-        new GoogleCloudStorageLineInputReader(filename, RECORD.length(), fileSize, (byte) '\n'));
+        new GoogleCloudStorageLineInputReader(filename, RECORD.length(), fileSize, (byte) '\n', inputOptions));
     verifyReaders(readers, true);
   }
 
   public void testAllSplitPoints() throws Exception {
     for (int splitPoint = 1; splitPoint < fileSize - 1; splitPoint++) {
       List<GoogleCloudStorageLineInputReader> readers = new ArrayList<>();
-      readers.add(new GoogleCloudStorageLineInputReader(filename, 0, splitPoint, (byte) '\n'));
+      readers.add(new GoogleCloudStorageLineInputReader(filename, 0, splitPoint, (byte) '\n', inputOptions));
       readers.add(
-          new GoogleCloudStorageLineInputReader(filename, splitPoint, fileSize, (byte) '\n'));
+          new GoogleCloudStorageLineInputReader(filename, splitPoint, fileSize, (byte) '\n', inputOptions));
       verifyReaders(readers, false);
     }
   }
@@ -54,9 +58,9 @@ public class GoogleCloudStorageLineInputReaderTest extends GoogleCloudStorageLin
   public void testAllSplitPointsWithSerialization() throws Exception {
     for (int splitPoint = 1; splitPoint < fileSize - 1; splitPoint++) {
       List<GoogleCloudStorageLineInputReader> readers = new ArrayList<>();
-      readers.add(new GoogleCloudStorageLineInputReader(filename, 0, splitPoint, (byte) '\n'));
+      readers.add(new GoogleCloudStorageLineInputReader(filename, 0, splitPoint, (byte) '\n', inputOptions));
       readers.add(
-          new GoogleCloudStorageLineInputReader(filename, splitPoint, fileSize, (byte) '\n'));
+          new GoogleCloudStorageLineInputReader(filename, splitPoint, fileSize, (byte) '\n', inputOptions));
       verifyReaders(readers, true);
     }
   }

--- a/java/src/test/java/com/google/appengine/tools/mapreduce/inputs/GoogleCloudStorageLineInputReaderTest.java
+++ b/java/src/test/java/com/google/appengine/tools/mapreduce/inputs/GoogleCloudStorageLineInputReaderTest.java
@@ -26,7 +26,7 @@ public class GoogleCloudStorageLineInputReaderTest extends GoogleCloudStorageLin
     super.setUp();
     filename = new GcsFilename(cloudStorageIntegrationTestHelper.getBucket(), FILENAME);
     fileSize = createFile(filename.getObjectName(), RECORD, RECORDS_COUNT);
-    inputOptions = GoogleCloudStorageLineInput.BaseOptions.defaults().withCredentials(cloudStorageIntegrationTestHelper.getCredentials());
+    inputOptions = GoogleCloudStorageLineInput.BaseOptions.defaults().withServiceAccountKey(cloudStorageIntegrationTestHelper.getBase64EncodedServiceAccountKey());
   }
 
   public void testSingleSplitPoint() throws Exception {

--- a/java/src/test/java/com/google/appengine/tools/mapreduce/inputs/GoogleCloudStorageLineInputReaderTest.java
+++ b/java/src/test/java/com/google/appengine/tools/mapreduce/inputs/GoogleCloudStorageLineInputReaderTest.java
@@ -1,6 +1,6 @@
 package com.google.appengine.tools.mapreduce.inputs;
 
-import com.google.appengine.tools.cloudstorage.GcsFilename;
+import com.google.appengine.tools.mapreduce.GcsFilename;
 import com.google.appengine.tools.mapreduce.impl.util.SerializationUtil;
 
 import java.io.IOException;
@@ -13,17 +13,17 @@ import java.util.NoSuchElementException;
 public class GoogleCloudStorageLineInputReaderTest extends GoogleCloudStorageLineInputTestCase {
 
   private static final String FILENAME = "GoogleCloudStorageLineInputReaderTestFile";
-  private static final String BUCKET = "GoogleCloudStorageInputReaderTestBucket";
   public static final String RECORD = "01234567890\n";
   public static final int RECORDS_COUNT = 10;
 
-  GcsFilename filename = new GcsFilename(BUCKET, FILENAME);
+  GcsFilename filename;
   long fileSize;
 
   @Override
   public void setUp() throws Exception {
     super.setUp();
-    fileSize = createFile(filename, RECORD, RECORDS_COUNT);
+    filename = new GcsFilename(cloudStorageIntegrationTestHelper.getBucket(), FILENAME);
+    fileSize = createFile(filename.getObjectName(), RECORD, RECORDS_COUNT);
   }
   public void testSingleSplitPoint() throws Exception {
     List<GoogleCloudStorageLineInputReader> readers = new ArrayList<>();

--- a/java/src/test/java/com/google/appengine/tools/mapreduce/inputs/GoogleCloudStorageLineInputTest.java
+++ b/java/src/test/java/com/google/appengine/tools/mapreduce/inputs/GoogleCloudStorageLineInputTest.java
@@ -23,7 +23,7 @@ public class GoogleCloudStorageLineInputTest extends GoogleCloudStorageLineInput
     super.setUp();
     filename = new GcsFilename(cloudStorageIntegrationTestHelper.getBucket(), FILENAME);
     fileSize = createFile(filename.getObjectName(), RECORD, RECORDS_COUNT);
-    inputOptions = GoogleCloudStorageLineInput.BaseOptions.defaults().withCredentials(cloudStorageIntegrationTestHelper.getCredentials());
+    inputOptions = GoogleCloudStorageLineInput.BaseOptions.defaults().withServiceAccountKey(cloudStorageIntegrationTestHelper.getBase64EncodedServiceAccountKey());
   }
 
   public void testSplit() throws Exception {

--- a/java/src/test/java/com/google/appengine/tools/mapreduce/inputs/GoogleCloudStorageLineInputTest.java
+++ b/java/src/test/java/com/google/appengine/tools/mapreduce/inputs/GoogleCloudStorageLineInputTest.java
@@ -16,16 +16,18 @@ public class GoogleCloudStorageLineInputTest extends GoogleCloudStorageLineInput
 
   GcsFilename filename;
   long fileSize;
+  GoogleCloudStorageLineInput.BaseOptions inputOptions;
 
   @Override
   public void setUp() throws Exception {
     super.setUp();
     filename = new GcsFilename(cloudStorageIntegrationTestHelper.getBucket(), FILENAME);
     fileSize = createFile(filename.getObjectName(), RECORD, RECORDS_COUNT);
+    inputOptions = GoogleCloudStorageLineInput.BaseOptions.defaults().withCredentials(cloudStorageIntegrationTestHelper.getCredentials());
   }
 
   public void testSplit() throws Exception {
-    GoogleCloudStorageLineInput input = new GoogleCloudStorageLineInput(filename, (byte) '\n', 4);
+    GoogleCloudStorageLineInput input = new GoogleCloudStorageLineInput(filename, (byte) '\n', 4, inputOptions);
     List<? extends InputReader<byte[]>> readers = input.createReaders();
     assertEquals(4, readers.size());
     assertSplitRange(0, 3000, readers.get(0));
@@ -35,7 +37,7 @@ public class GoogleCloudStorageLineInputTest extends GoogleCloudStorageLineInput
   }
 
   public void testUnevenSplit() throws Exception {
-    GoogleCloudStorageLineInput input = new GoogleCloudStorageLineInput(filename, (byte) '\n', 7);
+    GoogleCloudStorageLineInput input = new GoogleCloudStorageLineInput(filename, (byte) '\n', 7, inputOptions);
     List<? extends InputReader<byte[]>> readers = input.createReaders();
     assertEquals(7, readers.size());
     assertSplitRange(0, 1714, readers.get(0));

--- a/java/src/test/java/com/google/appengine/tools/mapreduce/inputs/GoogleCloudStorageLineInputTest.java
+++ b/java/src/test/java/com/google/appengine/tools/mapreduce/inputs/GoogleCloudStorageLineInputTest.java
@@ -1,6 +1,6 @@
 package com.google.appengine.tools.mapreduce.inputs;
 
-import com.google.appengine.tools.cloudstorage.GcsFilename;
+import com.google.appengine.tools.mapreduce.GcsFilename;
 import com.google.appengine.tools.mapreduce.InputReader;
 
 import java.util.List;
@@ -11,17 +11,17 @@ import java.util.List;
 public class GoogleCloudStorageLineInputTest extends GoogleCloudStorageLineInputTestCase {
 
   private static final String FILENAME = "CloudStorageLineInputTestFile";
-  private static final String BUCKET = "CloudStorageLineInputTestBucket";
   public static final String RECORD = "01234567890\n";
   public static final int RECORDS_COUNT = 1000;
 
-  GcsFilename filename = new GcsFilename(BUCKET, FILENAME);
+  GcsFilename filename;
   long fileSize;
 
   @Override
   public void setUp() throws Exception {
     super.setUp();
-    fileSize = createFile(filename, RECORD, RECORDS_COUNT);
+    filename = new GcsFilename(cloudStorageIntegrationTestHelper.getBucket(), FILENAME);
+    fileSize = createFile(filename.getObjectName(), RECORD, RECORDS_COUNT);
   }
 
   public void testSplit() throws Exception {

--- a/java/src/test/java/com/google/appengine/tools/mapreduce/inputs/GoogleCloudStorageLineInputTestCase.java
+++ b/java/src/test/java/com/google/appengine/tools/mapreduce/inputs/GoogleCloudStorageLineInputTestCase.java
@@ -20,13 +20,13 @@ abstract class GoogleCloudStorageLineInputTestCase extends TestCase  {
   CloudStorageIntegrationTestHelper cloudStorageIntegrationTestHelper = new CloudStorageIntegrationTestHelper();
 
   private final LocalServiceTestHelper helper = new LocalServiceTestHelper(
-      new CloudStorageIntegrationTestHelper(),
       new LocalDatastoreServiceTestConfig());
 
   @Override
   public void setUp() throws Exception {
     super.setUp();
     helper.setUp();
+    cloudStorageIntegrationTestHelper.setUp();
   }
 
   long createFile(String filename, String record, int recordsCount) throws IOException {
@@ -42,7 +42,7 @@ abstract class GoogleCloudStorageLineInputTestCase extends TestCase  {
   @Override
   public void tearDown() throws Exception {
     helper.tearDown();
-    cloudStorageIntegrationTestHelper.setUp();
+    cloudStorageIntegrationTestHelper.tearDown();
     super.tearDown();
   }
 }

--- a/java/src/test/java/com/google/appengine/tools/mapreduce/inputs/GoogleCloudStorageLineInputTestCase.java
+++ b/java/src/test/java/com/google/appengine/tools/mapreduce/inputs/GoogleCloudStorageLineInputTestCase.java
@@ -9,6 +9,7 @@ import com.google.appengine.tools.development.testing.LocalBlobstoreServiceTestC
 import com.google.appengine.tools.development.testing.LocalDatastoreServiceTestConfig;
 import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
 
+import com.google.appengine.tools.mapreduce.CloudStorageIntegrationTestHelper;
 import junit.framework.TestCase;
 
 import java.io.IOException;
@@ -16,10 +17,10 @@ import java.nio.ByteBuffer;
 
 /**
  */
-abstract class GoogleCloudStorageLineInputTestCase extends TestCase {
+abstract class GoogleCloudStorageLineInputTestCase extends TestCase  {
 
   private final LocalServiceTestHelper helper = new LocalServiceTestHelper(
-      new LocalBlobstoreServiceTestConfig(),
+      new CloudStorageIntegrationTestHelper(),
       new LocalDatastoreServiceTestConfig());
 
   @Override

--- a/java/src/test/java/com/google/appengine/tools/mapreduce/inputs/GoogleCloudStorageLineInputTestCase.java
+++ b/java/src/test/java/com/google/appengine/tools/mapreduce/inputs/GoogleCloudStorageLineInputTestCase.java
@@ -17,7 +17,7 @@ import java.nio.ByteBuffer;
  */
 abstract class GoogleCloudStorageLineInputTestCase extends TestCase  {
 
-  CloudStorageIntegrationTestHelper cloudStorageIntegrationTestHelper = new CloudStorageIntegrationTestHelper();
+  CloudStorageIntegrationTestHelper cloudStorageIntegrationTestHelper;
 
   private final LocalServiceTestHelper helper = new LocalServiceTestHelper(
       new LocalDatastoreServiceTestConfig());
@@ -26,6 +26,7 @@ abstract class GoogleCloudStorageLineInputTestCase extends TestCase  {
   public void setUp() throws Exception {
     super.setUp();
     helper.setUp();
+    cloudStorageIntegrationTestHelper = new CloudStorageIntegrationTestHelper();
     cloudStorageIntegrationTestHelper.setUp();
   }
 

--- a/java/src/test/java/com/google/appengine/tools/mapreduce/outputs/BigQueryGoogleCloudStorageStoreOutputTest.java
+++ b/java/src/test/java/com/google/appengine/tools/mapreduce/outputs/BigQueryGoogleCloudStorageStoreOutputTest.java
@@ -15,7 +15,6 @@ import com.google.common.collect.Lists;
 import junit.framework.TestCase;
 
 import lombok.Getter;
-import org.junit.AfterClass;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -56,6 +55,7 @@ public class BigQueryGoogleCloudStorageStoreOutputTest extends TestCase {
       writer.beginShard();
       writer.beginSlice();
       writer = SerializationUtil.clone(writer);
+      writer.beginSlice(); //30 Apr 2020: added beginSlice() here, not at all clear whether omission was intentional or bug
       writer.write(new Father(true, "Father",
           Lists.newArrayList(new Child("Childone", 1), new Child("childtwo", 2))));
       writer.endSlice();

--- a/java/src/test/java/com/google/appengine/tools/mapreduce/outputs/BigQueryGoogleCloudStorageStoreOutputTest.java
+++ b/java/src/test/java/com/google/appengine/tools/mapreduce/outputs/BigQueryGoogleCloudStorageStoreOutputTest.java
@@ -14,6 +14,8 @@ import com.google.common.collect.Lists;
 
 import junit.framework.TestCase;
 
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -23,21 +25,29 @@ import java.util.List;
 import java.util.Map;
 
 public class BigQueryGoogleCloudStorageStoreOutputTest extends TestCase {
-  private static final String BUCKET = "test-bigquery-loader";
 
   private final LocalServiceTestHelper helper = new LocalServiceTestHelper();
 
-  CloudStorageIntegrationTestHelper storageIntegrationTestHelper = new CloudStorageIntegrationTestHelper();
+  CloudStorageIntegrationTestHelper storageIntegrationTestHelper;
+
+  @BeforeClass
+  public void setupStorage() {
+    storageIntegrationTestHelper = new CloudStorageIntegrationTestHelper();
+    storageIntegrationTestHelper.setUp();
+  }
 
   @Override
   protected void setUp() throws Exception {
     helper.setUp();
-    storageIntegrationTestHelper.setUp();
   }
 
   @Override
   protected void tearDown() throws Exception {
     helper.tearDown();
+  }
+
+  @AfterClass
+  public void tearDownStorage(){
     storageIntegrationTestHelper.tearDown();
   }
 

--- a/java/src/test/java/com/google/appengine/tools/mapreduce/outputs/BigQueryGoogleCloudStorageStoreOutputTest.java
+++ b/java/src/test/java/com/google/appengine/tools/mapreduce/outputs/BigQueryGoogleCloudStorageStoreOutputTest.java
@@ -4,6 +4,7 @@ import com.google.api.services.bigquery.model.TableFieldSchema;
 import com.google.api.services.bigquery.model.TableSchema;
 import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
 import com.google.appengine.tools.mapreduce.BigQueryFieldMode;
+import com.google.appengine.tools.mapreduce.CloudStorageIntegrationTestHelper;
 import com.google.appengine.tools.mapreduce.GoogleCloudStorageFileSet;
 import com.google.appengine.tools.mapreduce.impl.BigQueryMarshallerByType;
 import com.google.appengine.tools.mapreduce.impl.util.SerializationUtil;
@@ -26,21 +27,25 @@ public class BigQueryGoogleCloudStorageStoreOutputTest extends TestCase {
 
   private final LocalServiceTestHelper helper = new LocalServiceTestHelper();
 
+  CloudStorageIntegrationTestHelper storageIntegrationTestHelper;
+
   @Override
   protected void setUp() throws Exception {
     helper.setUp();
+    storageIntegrationTestHelper.setUp();
   }
 
   @Override
   protected void tearDown() throws Exception {
     helper.tearDown();
+    storageIntegrationTestHelper.tearDown();
   }
 
   @Test
   public void testBigQueryResult() throws IOException {
     BigQueryGoogleCloudStorageStoreOutput<Father> creator =
         new BigQueryGoogleCloudStorageStoreOutput<Father>(
-            new BigQueryMarshallerByType<Father>(Father.class), BUCKET, "testJob");
+            new BigQueryMarshallerByType<Father>(Father.class), storageIntegrationTestHelper.getBucket(), "testJob", GoogleCloudStorageFileOutput.BaseOptions.defaults().withCredentials(storageIntegrationTestHelper.getCredentials()).withProjectId(storageIntegrationTestHelper.getProjectId()));
 
     List<MarshallingOutputWriter<Father>> writers = creator.createWriters(5);
     List<MarshallingOutputWriter<Father>> finished = new ArrayList<>();

--- a/java/src/test/java/com/google/appengine/tools/mapreduce/outputs/BigQueryGoogleCloudStorageStoreOutputTest.java
+++ b/java/src/test/java/com/google/appengine/tools/mapreduce/outputs/BigQueryGoogleCloudStorageStoreOutputTest.java
@@ -16,7 +16,6 @@ import junit.framework.TestCase;
 
 import lombok.Getter;
 import org.junit.AfterClass;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -30,26 +29,18 @@ public class BigQueryGoogleCloudStorageStoreOutputTest extends TestCase {
   private final LocalServiceTestHelper helper = new LocalServiceTestHelper();
 
   @Getter
-  static CloudStorageIntegrationTestHelper storageIntegrationTestHelper;
+  CloudStorageIntegrationTestHelper storageIntegrationTestHelper;
 
-  @BeforeClass
-  public static void setupStorage() {
+  @Override
+  protected void setUp() throws Exception {
+    helper.setUp();
     storageIntegrationTestHelper = new CloudStorageIntegrationTestHelper();
     storageIntegrationTestHelper.setUp();
   }
 
   @Override
-  protected void setUp() throws Exception {
-    helper.setUp();
-  }
-
-  @Override
   protected void tearDown() throws Exception {
     helper.tearDown();
-  }
-
-  @AfterClass
-  public static void tearDownStorage(){
     storageIntegrationTestHelper.tearDown();
   }
 

--- a/java/src/test/java/com/google/appengine/tools/mapreduce/outputs/BigQueryGoogleCloudStorageStoreOutputTest.java
+++ b/java/src/test/java/com/google/appengine/tools/mapreduce/outputs/BigQueryGoogleCloudStorageStoreOutputTest.java
@@ -27,7 +27,7 @@ public class BigQueryGoogleCloudStorageStoreOutputTest extends TestCase {
 
   private final LocalServiceTestHelper helper = new LocalServiceTestHelper();
 
-  CloudStorageIntegrationTestHelper storageIntegrationTestHelper;
+  CloudStorageIntegrationTestHelper storageIntegrationTestHelper = new CloudStorageIntegrationTestHelper();
 
   @Override
   protected void setUp() throws Exception {

--- a/java/src/test/java/com/google/appengine/tools/mapreduce/outputs/BigQueryGoogleCloudStorageStoreOutputTest.java
+++ b/java/src/test/java/com/google/appengine/tools/mapreduce/outputs/BigQueryGoogleCloudStorageStoreOutputTest.java
@@ -47,7 +47,9 @@ public class BigQueryGoogleCloudStorageStoreOutputTest extends TestCase {
   public void testBigQueryResult() throws IOException {
     BigQueryGoogleCloudStorageStoreOutput<Father> creator =
         new BigQueryGoogleCloudStorageStoreOutput<Father>(
-            new BigQueryMarshallerByType<Father>(Father.class), storageIntegrationTestHelper.getBucket(), "testJob", GoogleCloudStorageFileOutput.BaseOptions.defaults().withCredentials(storageIntegrationTestHelper.getCredentials()).withProjectId(storageIntegrationTestHelper.getProjectId()));
+            new BigQueryMarshallerByType<Father>(Father.class), storageIntegrationTestHelper.getBucket(), "testJob", GoogleCloudStorageFileOutput.BaseOptions.defaults()
+          .withServiceAccountKey(storageIntegrationTestHelper.getBase64EncodedServiceAccountKey())
+          .withProjectId(storageIntegrationTestHelper.getProjectId()));
 
     List<MarshallingOutputWriter<Father>> writers = creator.createWriters(5);
     List<MarshallingOutputWriter<Father>> finished = new ArrayList<>();

--- a/java/src/test/java/com/google/appengine/tools/mapreduce/outputs/BigQueryGoogleCloudStorageStoreOutputTest.java
+++ b/java/src/test/java/com/google/appengine/tools/mapreduce/outputs/BigQueryGoogleCloudStorageStoreOutputTest.java
@@ -14,6 +14,7 @@ import com.google.common.collect.Lists;
 
 import junit.framework.TestCase;
 
+import lombok.Getter;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -28,10 +29,11 @@ public class BigQueryGoogleCloudStorageStoreOutputTest extends TestCase {
 
   private final LocalServiceTestHelper helper = new LocalServiceTestHelper();
 
-  CloudStorageIntegrationTestHelper storageIntegrationTestHelper;
+  @Getter
+  static CloudStorageIntegrationTestHelper storageIntegrationTestHelper;
 
   @BeforeClass
-  public void setupStorage() {
+  public static void setupStorage() {
     storageIntegrationTestHelper = new CloudStorageIntegrationTestHelper();
     storageIntegrationTestHelper.setUp();
   }
@@ -47,7 +49,7 @@ public class BigQueryGoogleCloudStorageStoreOutputTest extends TestCase {
   }
 
   @AfterClass
-  public void tearDownStorage(){
+  public static void tearDownStorage(){
     storageIntegrationTestHelper.tearDown();
   }
 

--- a/java/src/test/java/com/google/appengine/tools/mapreduce/outputs/BigQueryStoreResultTest.java
+++ b/java/src/test/java/com/google/appengine/tools/mapreduce/outputs/BigQueryStoreResultTest.java
@@ -11,6 +11,8 @@ import com.google.common.collect.Lists;
 
 import junit.framework.TestCase;
 
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -19,19 +21,28 @@ import java.util.List;
 public class BigQueryStoreResultTest extends TestCase {
 
   private final LocalServiceTestHelper helper = new LocalServiceTestHelper();
-  CloudStorageIntegrationTestHelper storageIntegrationTestHelper = new CloudStorageIntegrationTestHelper();
+  CloudStorageIntegrationTestHelper storageIntegrationTestHelper;
+
+  @BeforeClass
+  public void setupStorage() {
+    storageIntegrationTestHelper = new CloudStorageIntegrationTestHelper();
+    storageIntegrationTestHelper.setUp();
+  }
 
   @Override
   protected void setUp() throws Exception {
     super.setUp();
     helper.setUp();
-    storageIntegrationTestHelper.setUp();
   }
 
   @Override
   protected void tearDown() throws Exception {
     super.tearDown();
     helper.tearDown();
+  }
+
+  @AfterClass
+  public void tearDownStorage() {
     storageIntegrationTestHelper.tearDown();
   }
 

--- a/java/src/test/java/com/google/appengine/tools/mapreduce/outputs/BigQueryStoreResultTest.java
+++ b/java/src/test/java/com/google/appengine/tools/mapreduce/outputs/BigQueryStoreResultTest.java
@@ -19,7 +19,7 @@ import java.util.List;
 public class BigQueryStoreResultTest extends TestCase {
 
   private final LocalServiceTestHelper helper = new LocalServiceTestHelper();
-  CloudStorageIntegrationTestHelper storageIntegrationTestHelper;
+  CloudStorageIntegrationTestHelper storageIntegrationTestHelper = new CloudStorageIntegrationTestHelper();
 
   @Override
   protected void setUp() throws Exception {

--- a/java/src/test/java/com/google/appengine/tools/mapreduce/outputs/BigQueryStoreResultTest.java
+++ b/java/src/test/java/com/google/appengine/tools/mapreduce/outputs/BigQueryStoreResultTest.java
@@ -12,8 +12,6 @@ import com.google.common.collect.Lists;
 import junit.framework.TestCase;
 
 import lombok.Getter;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -23,28 +21,21 @@ public class BigQueryStoreResultTest extends TestCase {
 
   private final LocalServiceTestHelper helper = new LocalServiceTestHelper();
   @Getter
-  static CloudStorageIntegrationTestHelper storageIntegrationTestHelper;
+  CloudStorageIntegrationTestHelper storageIntegrationTestHelper;
 
-  @BeforeClass
-  public static void setupStorage() {
-    storageIntegrationTestHelper = new CloudStorageIntegrationTestHelper();
-    storageIntegrationTestHelper.setUp();
-  }
 
   @Override
   protected void setUp() throws Exception {
     super.setUp();
     helper.setUp();
+    storageIntegrationTestHelper = new CloudStorageIntegrationTestHelper();
+    storageIntegrationTestHelper.setUp();
   }
 
   @Override
   protected void tearDown() throws Exception {
     super.tearDown();
     helper.tearDown();
-  }
-
-  @AfterClass
-  public static void tearDownStorage() {
     storageIntegrationTestHelper.tearDown();
   }
 

--- a/java/src/test/java/com/google/appengine/tools/mapreduce/outputs/BigQueryStoreResultTest.java
+++ b/java/src/test/java/com/google/appengine/tools/mapreduce/outputs/BigQueryStoreResultTest.java
@@ -11,6 +11,7 @@ import com.google.common.collect.Lists;
 
 import junit.framework.TestCase;
 
+import lombok.Getter;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -21,10 +22,11 @@ import java.util.List;
 public class BigQueryStoreResultTest extends TestCase {
 
   private final LocalServiceTestHelper helper = new LocalServiceTestHelper();
-  CloudStorageIntegrationTestHelper storageIntegrationTestHelper;
+  @Getter
+  static CloudStorageIntegrationTestHelper storageIntegrationTestHelper;
 
   @BeforeClass
-  public void setupStorage() {
+  public static void setupStorage() {
     storageIntegrationTestHelper = new CloudStorageIntegrationTestHelper();
     storageIntegrationTestHelper.setUp();
   }
@@ -42,7 +44,7 @@ public class BigQueryStoreResultTest extends TestCase {
   }
 
   @AfterClass
-  public void tearDownStorage() {
+  public static void tearDownStorage() {
     storageIntegrationTestHelper.tearDown();
   }
 

--- a/java/src/test/java/com/google/appengine/tools/mapreduce/outputs/BigQueryStoreResultTest.java
+++ b/java/src/test/java/com/google/appengine/tools/mapreduce/outputs/BigQueryStoreResultTest.java
@@ -44,7 +44,7 @@ public class BigQueryStoreResultTest extends TestCase {
     BigQueryGoogleCloudStorageStoreOutput<Father> creator =
         new BigQueryGoogleCloudStorageStoreOutput<Father>(
             new BigQueryMarshallerByType<Father>(Father.class), storageIntegrationTestHelper.getBucket(), "testJob", GoogleCloudStorageFileOutput.BaseOptions.defaults()
-        .withCredentials(storageIntegrationTestHelper.getCredentials())
+        .withServiceAccountKey(storageIntegrationTestHelper.getBase64EncodedServiceAccountKey())
         .withProjectId(storageIntegrationTestHelper.getProjectId()));
 
     List<MarshallingOutputWriter<Father>> writers = creator.createWriters(5);

--- a/java/src/test/java/com/google/appengine/tools/mapreduce/outputs/BigQueryStoreResultTest.java
+++ b/java/src/test/java/com/google/appengine/tools/mapreduce/outputs/BigQueryStoreResultTest.java
@@ -1,6 +1,7 @@
 package com.google.appengine.tools.mapreduce.outputs;
 
 import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
+import com.google.appengine.tools.mapreduce.CloudStorageIntegrationTestHelper;
 import com.google.appengine.tools.mapreduce.GoogleCloudStorageFileSet;
 import com.google.appengine.tools.mapreduce.impl.BigQueryMarshallerByType;
 import com.google.appengine.tools.mapreduce.testmodels.Child;
@@ -16,27 +17,31 @@ import java.io.IOException;
 import java.util.List;
 
 public class BigQueryStoreResultTest extends TestCase {
-  private static final String BUCKET = "test-bigquery-loader";
 
   private final LocalServiceTestHelper helper = new LocalServiceTestHelper();
+  CloudStorageIntegrationTestHelper storageIntegrationTestHelper;
 
   @Override
   protected void setUp() throws Exception {
     super.setUp();
     helper.setUp();
+    storageIntegrationTestHelper.setUp();
   }
 
   @Override
   protected void tearDown() throws Exception {
     super.tearDown();
     helper.tearDown();
+    storageIntegrationTestHelper.tearDown();
   }
 
   @Test
   public void testSerialization() throws IOException {
     BigQueryGoogleCloudStorageStoreOutput<Father> creator =
         new BigQueryGoogleCloudStorageStoreOutput<Father>(
-            new BigQueryMarshallerByType<Father>(Father.class), BUCKET, "testJob");
+            new BigQueryMarshallerByType<Father>(Father.class), storageIntegrationTestHelper.getBucket(), "testJob", GoogleCloudStorageFileOutput.BaseOptions.defaults()
+        .withCredentials(storageIntegrationTestHelper.getCredentials())
+        .withProjectId(storageIntegrationTestHelper.getProjectId()));
 
     List<MarshallingOutputWriter<Father>> writers = creator.createWriters(5);
     for (MarshallingOutputWriter<Father> writer : writers) {

--- a/java/src/test/java/com/google/appengine/tools/mapreduce/outputs/GoogleCloudStorageFileOutputTest.java
+++ b/java/src/test/java/com/google/appengine/tools/mapreduce/outputs/GoogleCloudStorageFileOutputTest.java
@@ -32,7 +32,7 @@ public class GoogleCloudStorageFileOutputTest extends TestCase {
   // there will be some left over.
   private static final byte[] LARGE_CONTENT = new byte[(int) (1024 * 1024 * 2.5)];
 
-  CloudStorageIntegrationTestHelper storageIntegrationTestHelper;
+  CloudStorageIntegrationTestHelper storageIntegrationTestHelper = new CloudStorageIntegrationTestHelper();
 
 
   @Override

--- a/java/src/test/java/com/google/appengine/tools/mapreduce/outputs/GoogleCloudStorageFileOutputTest.java
+++ b/java/src/test/java/com/google/appengine/tools/mapreduce/outputs/GoogleCloudStorageFileOutputTest.java
@@ -54,7 +54,7 @@ public class GoogleCloudStorageFileOutputTest extends TestCase {
 
   public void testFilesAreWritten() throws IOException {
     GoogleCloudStorageFileOutput creator =
-        new GoogleCloudStorageFileOutput(storageIntegrationTestHelper.getBucket(), FILE_NAME_PATTERN, MIME_TYPE, GoogleCloudStorageFileOutputWriter.BaseOptions.defaults().withCredentials(storageIntegrationTestHelper.getCredentials()).withProjectId(getProjectId()));
+        new GoogleCloudStorageFileOutput(storageIntegrationTestHelper.getBucket(), FILE_NAME_PATTERN, MIME_TYPE, GoogleCloudStorageFileOutput.BaseOptions.defaults().withCredentials(storageIntegrationTestHelper.getCredentials()).withProjectId(getProjectId()));
     List<? extends OutputWriter<ByteBuffer>> writers = creator.createWriters(NUM_SHARDS);
     assertEquals(NUM_SHARDS, writers.size());
     beginShard(writers);
@@ -91,7 +91,7 @@ public class GoogleCloudStorageFileOutputTest extends TestCase {
 
   private void testSlicing(byte[] content) throws IOException, ClassNotFoundException {
     GoogleCloudStorageFileOutput creator =
-      new GoogleCloudStorageFileOutput(storageIntegrationTestHelper.getBucket(), FILE_NAME_PATTERN, MIME_TYPE, GoogleCloudStorageFileOutputWriter.BaseOptions.defaults().withCredentials(storageIntegrationTestHelper.getCredentials()).withProjectId(getProjectId()));
+      new GoogleCloudStorageFileOutput(storageIntegrationTestHelper.getBucket(), FILE_NAME_PATTERN, MIME_TYPE, GoogleCloudStorageFileOutput.BaseOptions.defaults().withCredentials(storageIntegrationTestHelper.getCredentials()).withProjectId(getProjectId()));
     List<? extends OutputWriter<ByteBuffer>> writers = creator.createWriters(NUM_SHARDS);
     assertEquals(NUM_SHARDS, writers.size());
     beginShard(writers);

--- a/java/src/test/java/com/google/appengine/tools/mapreduce/outputs/GoogleCloudStorageFileOutputTest.java
+++ b/java/src/test/java/com/google/appengine/tools/mapreduce/outputs/GoogleCloudStorageFileOutputTest.java
@@ -8,6 +8,8 @@ import com.google.appengine.tools.mapreduce.OutputWriter;
 import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.BlobId;
 import junit.framework.TestCase;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -32,13 +34,16 @@ public class GoogleCloudStorageFileOutputTest extends TestCase {
   // there will be some left over.
   private static final byte[] LARGE_CONTENT = new byte[(int) (1024 * 1024 * 2.5)];
 
-  CloudStorageIntegrationTestHelper storageIntegrationTestHelper = new CloudStorageIntegrationTestHelper();
+  CloudStorageIntegrationTestHelper storageIntegrationTestHelper;
 
-
+  @BeforeClass
+  public void setupStorage() {
+    storageIntegrationTestHelper = new CloudStorageIntegrationTestHelper();
+    storageIntegrationTestHelper.setUp();
+  }
   @Override
   protected void setUp() throws Exception {
     super.setUp();
-    storageIntegrationTestHelper.setUp();
     // Filling the large_content buffer with a non-repeating but consistent pattern.
     Random r = new Random(0);
     r.nextBytes(LARGE_CONTENT);
@@ -51,6 +56,10 @@ public class GoogleCloudStorageFileOutputTest extends TestCase {
     super.tearDown();
   }
 
+  @AfterClass
+  protected void tearDownStorage() throws Exception {
+    storageIntegrationTestHelper.tearDown();
+  }
 
   public void testFilesAreWritten() throws IOException {
     GoogleCloudStorageFileOutput creator =

--- a/java/src/test/java/com/google/appengine/tools/mapreduce/outputs/GoogleCloudStorageFileOutputTest.java
+++ b/java/src/test/java/com/google/appengine/tools/mapreduce/outputs/GoogleCloudStorageFileOutputTest.java
@@ -36,16 +36,18 @@ public class GoogleCloudStorageFileOutputTest extends TestCase {
   private static final byte[] LARGE_CONTENT = new byte[(int) (1024 * 1024 * 2.5)];
 
   @Getter
-  static CloudStorageIntegrationTestHelper storageIntegrationTestHelper;
+  CloudStorageIntegrationTestHelper storageIntegrationTestHelper;
 
   @BeforeClass
   public static void setupStorage() {
-    storageIntegrationTestHelper = new CloudStorageIntegrationTestHelper();
-    storageIntegrationTestHelper.setUp();
+
   }
   @Override
   protected void setUp() throws Exception {
     super.setUp();
+    storageIntegrationTestHelper = new CloudStorageIntegrationTestHelper();
+    storageIntegrationTestHelper.setUp();
+
     // Filling the large_content buffer with a non-repeating but consistent pattern.
     Random r = new Random(0);
     r.nextBytes(LARGE_CONTENT);
@@ -56,11 +58,6 @@ public class GoogleCloudStorageFileOutputTest extends TestCase {
   protected void tearDown() throws Exception {
     storageIntegrationTestHelper.tearDown();
     super.tearDown();
-  }
-
-  @AfterClass
-  public static void tearDownStorage() throws Exception {
-    storageIntegrationTestHelper.tearDown();
   }
 
   public void testFilesAreWritten() throws IOException {

--- a/java/src/test/java/com/google/appengine/tools/mapreduce/outputs/GoogleCloudStorageFileOutputTest.java
+++ b/java/src/test/java/com/google/appengine/tools/mapreduce/outputs/GoogleCloudStorageFileOutputTest.java
@@ -8,6 +8,7 @@ import com.google.appengine.tools.mapreduce.OutputWriter;
 import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.BlobId;
 import junit.framework.TestCase;
+import lombok.Getter;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 
@@ -34,10 +35,11 @@ public class GoogleCloudStorageFileOutputTest extends TestCase {
   // there will be some left over.
   private static final byte[] LARGE_CONTENT = new byte[(int) (1024 * 1024 * 2.5)];
 
-  CloudStorageIntegrationTestHelper storageIntegrationTestHelper;
+  @Getter
+  static CloudStorageIntegrationTestHelper storageIntegrationTestHelper;
 
   @BeforeClass
-  public void setupStorage() {
+  public static void setupStorage() {
     storageIntegrationTestHelper = new CloudStorageIntegrationTestHelper();
     storageIntegrationTestHelper.setUp();
   }
@@ -57,7 +59,7 @@ public class GoogleCloudStorageFileOutputTest extends TestCase {
   }
 
   @AfterClass
-  protected void tearDownStorage() throws Exception {
+  public static void tearDownStorage() throws Exception {
     storageIntegrationTestHelper.tearDown();
   }
 

--- a/java/src/test/java/com/google/appengine/tools/mapreduce/outputs/GoogleCloudStorageFileOutputTest.java
+++ b/java/src/test/java/com/google/appengine/tools/mapreduce/outputs/GoogleCloudStorageFileOutputTest.java
@@ -62,7 +62,7 @@ public class GoogleCloudStorageFileOutputTest extends TestCase {
 
   public void testFilesAreWritten() throws IOException {
     GoogleCloudStorageFileOutput creator =
-        new GoogleCloudStorageFileOutput(storageIntegrationTestHelper.getBucket(), FILE_NAME_PATTERN, MIME_TYPE, GoogleCloudStorageFileOutput.BaseOptions.defaults().withCredentials(storageIntegrationTestHelper.getCredentials()).withProjectId(getProjectId()));
+        new GoogleCloudStorageFileOutput(storageIntegrationTestHelper.getBucket(), FILE_NAME_PATTERN, MIME_TYPE, GoogleCloudStorageFileOutput.BaseOptions.defaults().withServiceAccountKey(storageIntegrationTestHelper.getBase64EncodedServiceAccountKey()).withProjectId(getProjectId()));
     List<? extends OutputWriter<ByteBuffer>> writers = creator.createWriters(NUM_SHARDS);
     assertEquals(NUM_SHARDS, writers.size());
     beginShard(writers);
@@ -99,7 +99,7 @@ public class GoogleCloudStorageFileOutputTest extends TestCase {
 
   private void testSlicing(byte[] content) throws IOException, ClassNotFoundException {
     GoogleCloudStorageFileOutput creator =
-      new GoogleCloudStorageFileOutput(storageIntegrationTestHelper.getBucket(), FILE_NAME_PATTERN, MIME_TYPE, GoogleCloudStorageFileOutput.BaseOptions.defaults().withCredentials(storageIntegrationTestHelper.getCredentials()).withProjectId(getProjectId()));
+      new GoogleCloudStorageFileOutput(storageIntegrationTestHelper.getBucket(), FILE_NAME_PATTERN, MIME_TYPE, GoogleCloudStorageFileOutput.BaseOptions.defaults().withServiceAccountKey(storageIntegrationTestHelper.getBase64EncodedServiceAccountKey()).withProjectId(getProjectId()));
     List<? extends OutputWriter<ByteBuffer>> writers = creator.createWriters(NUM_SHARDS);
     assertEquals(NUM_SHARDS, writers.size());
     beginShard(writers);

--- a/java/src/test/java/com/google/appengine/tools/mapreduce/outputs/SizeSegmentedGoogleCloudStorageFileOutputTest.java
+++ b/java/src/test/java/com/google/appengine/tools/mapreduce/outputs/SizeSegmentedGoogleCloudStorageFileOutputTest.java
@@ -9,6 +9,7 @@ import com.google.appengine.tools.mapreduce.impl.util.SerializationUtil;
 
 import com.google.cloud.storage.Blob;
 import junit.framework.TestCase;
+import lombok.Getter;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 
@@ -22,14 +23,15 @@ public class SizeSegmentedGoogleCloudStorageFileOutputTest extends TestCase {
 
   private final LocalServiceTestHelper helper = new LocalServiceTestHelper();
 
-  CloudStorageIntegrationTestHelper cloudStorageIntegrationTestHelper;
+  @Getter
+  static CloudStorageIntegrationTestHelper cloudStorageIntegrationTestHelper;
 
   private static final String MIME_TYPE = "application/json";
 
   GoogleCloudStorageFileOutput.Options options;
 
   @BeforeClass
-  public void setupStorage() {
+  public static void setupStorage() {
     cloudStorageIntegrationTestHelper = new CloudStorageIntegrationTestHelper();
     cloudStorageIntegrationTestHelper.setUp();
   }
@@ -49,7 +51,7 @@ public class SizeSegmentedGoogleCloudStorageFileOutputTest extends TestCase {
   }
 
   @AfterClass
-  protected void tearDownStorage() throws Exception {
+  public static void tearDownStorage() throws Exception {
     cloudStorageIntegrationTestHelper.tearDown();
   }
 

--- a/java/src/test/java/com/google/appengine/tools/mapreduce/outputs/SizeSegmentedGoogleCloudStorageFileOutputTest.java
+++ b/java/src/test/java/com/google/appengine/tools/mapreduce/outputs/SizeSegmentedGoogleCloudStorageFileOutputTest.java
@@ -1,14 +1,13 @@
 package com.google.appengine.tools.mapreduce.outputs;
 
-import com.google.appengine.tools.cloudstorage.GcsFileMetadata;
-import com.google.appengine.tools.cloudstorage.GcsService;
-import com.google.appengine.tools.cloudstorage.GcsServiceFactory;
 import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
+import com.google.appengine.tools.mapreduce.CloudStorageIntegrationTestHelper;
 import com.google.appengine.tools.mapreduce.GoogleCloudStorageFileSet;
 import com.google.appengine.tools.mapreduce.OutputWriter;
 import com.google.appengine.tools.mapreduce.impl.BigQueryConstants;
 import com.google.appengine.tools.mapreduce.impl.util.SerializationUtil;
 
+import com.google.cloud.storage.Blob;
 import junit.framework.TestCase;
 
 import java.io.IOException;
@@ -20,7 +19,8 @@ import java.util.Random;
 public class SizeSegmentedGoogleCloudStorageFileOutputTest extends TestCase {
 
   private final LocalServiceTestHelper helper = new LocalServiceTestHelper();
-  private final GcsService gcsService = GcsServiceFactory.createGcsService();
+
+  CloudStorageIntegrationTestHelper cloudStorageIntegrationTestHelper = new CloudStorageIntegrationTestHelper();
 
   private static final String BUCKET = "test-bigquery-loader";
   private static final String MIME_TYPE = "application/json";
@@ -29,12 +29,14 @@ public class SizeSegmentedGoogleCloudStorageFileOutputTest extends TestCase {
   protected void setUp() throws Exception {
     super.setUp();
     helper.setUp();
+    cloudStorageIntegrationTestHelper.setUp();
   }
 
   @Override
   protected void tearDown() throws Exception {
     super.tearDown();
     helper.tearDown();
+    cloudStorageIntegrationTestHelper.tearDown();
   }
 
   public void testFilesWritten() throws IOException {
@@ -65,9 +67,9 @@ public class SizeSegmentedGoogleCloudStorageFileOutputTest extends TestCase {
     GoogleCloudStorageFileSet filesWritten = segmenter.finish(finished);
     assertEquals(15, filesWritten.getNumFiles());
     for (int i = 0; i < filesWritten.getNumFiles(); i++) {
-      GcsFileMetadata metadata = gcsService.getMetadata(filesWritten.getFile(i));
-      assertNotNull(metadata);
-      assertEquals(MIME_TYPE, metadata.getOptions().getMimeType());
+      Blob blob = cloudStorageIntegrationTestHelper.getStorage().get(filesWritten.getFile(i).asBlobId());
+      assertNotNull(blob);
+      assertEquals(MIME_TYPE, blob.getContentType());
     }
   }
 
@@ -85,9 +87,9 @@ public class SizeSegmentedGoogleCloudStorageFileOutputTest extends TestCase {
     GoogleCloudStorageFileSet filesWritten = segmenter.finish(writers);
     assertEquals(countFiles, filesWritten.getNumFiles());
     for (int i = 0; i < filesWritten.getNumFiles(); i++) {
-      GcsFileMetadata metadata = gcsService.getMetadata(filesWritten.getFile(i));
-      assertNotNull(metadata);
-      assertEquals(MIME_TYPE, metadata.getOptions().getMimeType());
+      Blob blob = cloudStorageIntegrationTestHelper.getStorage().get(filesWritten.getFile(i).asBlobId());
+      assertNotNull(blob);
+      assertEquals(MIME_TYPE, blob.getContentType());
     }
   }
 

--- a/java/src/test/java/com/google/appengine/tools/mapreduce/outputs/SizeSegmentedGoogleCloudStorageFileOutputTest.java
+++ b/java/src/test/java/com/google/appengine/tools/mapreduce/outputs/SizeSegmentedGoogleCloudStorageFileOutputTest.java
@@ -25,11 +25,15 @@ public class SizeSegmentedGoogleCloudStorageFileOutputTest extends TestCase {
   private static final String BUCKET = "test-bigquery-loader";
   private static final String MIME_TYPE = "application/json";
 
+  GoogleCloudStorageFileOutput.Options options;
+
   @Override
   protected void setUp() throws Exception {
     super.setUp();
     helper.setUp();
     cloudStorageIntegrationTestHelper.setUp();
+    options = GoogleCloudStorageFileOutput.BaseOptions.defaults().withCredentials(cloudStorageIntegrationTestHelper.getCredentials()).withProjectId(cloudStorageIntegrationTestHelper.getProjectId());
+
   }
 
   @Override
@@ -37,6 +41,7 @@ public class SizeSegmentedGoogleCloudStorageFileOutputTest extends TestCase {
     super.tearDown();
     helper.tearDown();
     cloudStorageIntegrationTestHelper.tearDown();
+
   }
 
   public void testFilesWritten() throws IOException {
@@ -44,7 +49,7 @@ public class SizeSegmentedGoogleCloudStorageFileOutputTest extends TestCase {
     String fileNamePattern = String.format(BigQueryConstants.GCS_FILE_NAME_FORMAT, "testJob");
     SizeSegmentedGoogleCloudStorageFileOutput segmenter =
         new SizeSegmentedGoogleCloudStorageFileOutput(BUCKET, segmentSizeLimit, fileNamePattern,
-            BigQueryConstants.MIME_TYPE);
+            BigQueryConstants.MIME_TYPE, options);
     List<? extends OutputWriter<ByteBuffer>> writers = segmenter.createWriters(5);
     List<OutputWriter<ByteBuffer>> finished = new ArrayList<>();
     assertEquals(5, writers.size());
@@ -77,7 +82,7 @@ public class SizeSegmentedGoogleCloudStorageFileOutputTest extends TestCase {
     int segmentSizeLimit = 10;
     SizeSegmentedGoogleCloudStorageFileOutput segmenter =
         new SizeSegmentedGoogleCloudStorageFileOutput(BUCKET, segmentSizeLimit, "testJob",
-            BigQueryConstants.MIME_TYPE);
+            BigQueryConstants.MIME_TYPE, options);
     List<? extends OutputWriter<ByteBuffer>> writers = segmenter.createWriters(5);
     int countFiles = 0;
     for (OutputWriter<ByteBuffer> w : writers) {

--- a/java/src/test/java/com/google/appengine/tools/mapreduce/outputs/SizeSegmentedGoogleCloudStorageFileOutputTest.java
+++ b/java/src/test/java/com/google/appengine/tools/mapreduce/outputs/SizeSegmentedGoogleCloudStorageFileOutputTest.java
@@ -34,7 +34,7 @@ public class SizeSegmentedGoogleCloudStorageFileOutputTest extends TestCase {
     helper.setUp();
     cloudStorageIntegrationTestHelper = new CloudStorageIntegrationTestHelper();
     cloudStorageIntegrationTestHelper.setUp();
-    options = GoogleCloudStorageFileOutput.BaseOptions.defaults().withCredentials(cloudStorageIntegrationTestHelper.getCredentials()).withProjectId(cloudStorageIntegrationTestHelper.getProjectId());
+    options = GoogleCloudStorageFileOutput.BaseOptions.defaults().withServiceAccountKey(cloudStorageIntegrationTestHelper.getBase64EncodedServiceAccountKey()).withProjectId(cloudStorageIntegrationTestHelper.getProjectId());
 
   }
 

--- a/java/src/test/java/com/google/appengine/tools/mapreduce/outputs/SizeSegmentedGoogleCloudStorageFileOutputTest.java
+++ b/java/src/test/java/com/google/appengine/tools/mapreduce/outputs/SizeSegmentedGoogleCloudStorageFileOutputTest.java
@@ -22,7 +22,6 @@ public class SizeSegmentedGoogleCloudStorageFileOutputTest extends TestCase {
 
   CloudStorageIntegrationTestHelper cloudStorageIntegrationTestHelper = new CloudStorageIntegrationTestHelper();
 
-  private static final String BUCKET = "test-bigquery-loader";
   private static final String MIME_TYPE = "application/json";
 
   GoogleCloudStorageFileOutput.Options options;
@@ -48,7 +47,7 @@ public class SizeSegmentedGoogleCloudStorageFileOutputTest extends TestCase {
     int segmentSizeLimit = 10;
     String fileNamePattern = String.format(BigQueryConstants.GCS_FILE_NAME_FORMAT, "testJob");
     SizeSegmentedGoogleCloudStorageFileOutput segmenter =
-        new SizeSegmentedGoogleCloudStorageFileOutput(BUCKET, segmentSizeLimit, fileNamePattern,
+        new SizeSegmentedGoogleCloudStorageFileOutput(cloudStorageIntegrationTestHelper.getBucket(), segmentSizeLimit, fileNamePattern,
             BigQueryConstants.MIME_TYPE, options);
     List<? extends OutputWriter<ByteBuffer>> writers = segmenter.createWriters(5);
     List<OutputWriter<ByteBuffer>> finished = new ArrayList<>();
@@ -81,7 +80,7 @@ public class SizeSegmentedGoogleCloudStorageFileOutputTest extends TestCase {
   public void testSegmentation() throws IOException {
     int segmentSizeLimit = 10;
     SizeSegmentedGoogleCloudStorageFileOutput segmenter =
-        new SizeSegmentedGoogleCloudStorageFileOutput(BUCKET, segmentSizeLimit, "testJob",
+        new SizeSegmentedGoogleCloudStorageFileOutput(cloudStorageIntegrationTestHelper.getBucket(), segmentSizeLimit, "testJob",
             BigQueryConstants.MIME_TYPE, options);
     List<? extends OutputWriter<ByteBuffer>> writers = segmenter.createWriters(5);
     int countFiles = 0;

--- a/java/src/test/java/com/google/appengine/tools/mapreduce/outputs/SizeSegmentedGoogleCloudStorageFileOutputTest.java
+++ b/java/src/test/java/com/google/appengine/tools/mapreduce/outputs/SizeSegmentedGoogleCloudStorageFileOutputTest.java
@@ -10,8 +10,6 @@ import com.google.appengine.tools.mapreduce.impl.util.SerializationUtil;
 import com.google.cloud.storage.Blob;
 import junit.framework.TestCase;
 import lombok.Getter;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -30,16 +28,12 @@ public class SizeSegmentedGoogleCloudStorageFileOutputTest extends TestCase {
 
   GoogleCloudStorageFileOutput.Options options;
 
-  @BeforeClass
-  public static void setupStorage() {
-    cloudStorageIntegrationTestHelper = new CloudStorageIntegrationTestHelper();
-    cloudStorageIntegrationTestHelper.setUp();
-  }
-
   @Override
   protected void setUp() throws Exception {
     super.setUp();
     helper.setUp();
+    cloudStorageIntegrationTestHelper = new CloudStorageIntegrationTestHelper();
+    cloudStorageIntegrationTestHelper.setUp();
     options = GoogleCloudStorageFileOutput.BaseOptions.defaults().withCredentials(cloudStorageIntegrationTestHelper.getCredentials()).withProjectId(cloudStorageIntegrationTestHelper.getProjectId());
 
   }
@@ -49,12 +43,6 @@ public class SizeSegmentedGoogleCloudStorageFileOutputTest extends TestCase {
     super.tearDown();
     helper.tearDown();
   }
-
-  @AfterClass
-  public static void tearDownStorage() throws Exception {
-    cloudStorageIntegrationTestHelper.tearDown();
-  }
-
 
   public void testFilesWritten() throws IOException {
     int segmentSizeLimit = 10;

--- a/java/src/test/java/com/google/appengine/tools/mapreduce/outputs/SizeSegmentedGoogleCloudStorageFileOutputTest.java
+++ b/java/src/test/java/com/google/appengine/tools/mapreduce/outputs/SizeSegmentedGoogleCloudStorageFileOutputTest.java
@@ -9,6 +9,8 @@ import com.google.appengine.tools.mapreduce.impl.util.SerializationUtil;
 
 import com.google.cloud.storage.Blob;
 import junit.framework.TestCase;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -20,17 +22,22 @@ public class SizeSegmentedGoogleCloudStorageFileOutputTest extends TestCase {
 
   private final LocalServiceTestHelper helper = new LocalServiceTestHelper();
 
-  CloudStorageIntegrationTestHelper cloudStorageIntegrationTestHelper = new CloudStorageIntegrationTestHelper();
+  CloudStorageIntegrationTestHelper cloudStorageIntegrationTestHelper;
 
   private static final String MIME_TYPE = "application/json";
 
   GoogleCloudStorageFileOutput.Options options;
 
+  @BeforeClass
+  public void setupStorage() {
+    cloudStorageIntegrationTestHelper = new CloudStorageIntegrationTestHelper();
+    cloudStorageIntegrationTestHelper.setUp();
+  }
+
   @Override
   protected void setUp() throws Exception {
     super.setUp();
     helper.setUp();
-    cloudStorageIntegrationTestHelper.setUp();
     options = GoogleCloudStorageFileOutput.BaseOptions.defaults().withCredentials(cloudStorageIntegrationTestHelper.getCredentials()).withProjectId(cloudStorageIntegrationTestHelper.getProjectId());
 
   }
@@ -39,9 +46,13 @@ public class SizeSegmentedGoogleCloudStorageFileOutputTest extends TestCase {
   protected void tearDown() throws Exception {
     super.tearDown();
     helper.tearDown();
-    cloudStorageIntegrationTestHelper.tearDown();
-
   }
+
+  @AfterClass
+  protected void tearDownStorage() throws Exception {
+    cloudStorageIntegrationTestHelper.tearDown();
+  }
+
 
   public void testFilesWritten() throws IOException {
     int segmentSizeLimit = 10;

--- a/java/src/test/java/com/google/appengine/tools/mapreduce/servlets/ShufflerServletTest.java
+++ b/java/src/test/java/com/google/appengine/tools/mapreduce/servlets/ShufflerServletTest.java
@@ -42,9 +42,7 @@ import com.google.apphosting.api.ApiProxy;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.TreeMultimap;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.*;
 import org.junit.runner.RunWith;
 import org.junit.runners.BlockJUnit4ClassRunner;
 
@@ -126,17 +124,24 @@ public class ShufflerServletTest {
     }
   }
 
-  CloudStorageIntegrationTestHelper storageIntegrationTestHelper = new CloudStorageIntegrationTestHelper();
+  CloudStorageIntegrationTestHelper storageIntegrationTestHelper;
+
+  @BeforeClass
+  public void setupStorage() {
+    storageIntegrationTestHelper = new CloudStorageIntegrationTestHelper();
+    storageIntegrationTestHelper.setUp();
+  }
 
   @Before
   public void setUp() throws Exception {
     helper.setUp();
-    storageIntegrationTestHelper.setUp();
     ApiProxyLocal proxy = (ApiProxyLocal) ApiProxy.getDelegate();
     // Creating files is not allowed in some test execution environments, so don't.
     proxy.setProperty(LocalBlobstoreService.NO_STORAGE_PROPERTY, "true");
     WAIT_ON.drainPermits();
   }
+
+
 
   @After
   public void tearDown() throws Exception {
@@ -148,6 +153,10 @@ public class ShufflerServletTest {
       Thread.sleep(1000);
     }
     helper.tearDown();
+  }
+
+  @AfterClass
+  public void teardownStorage() {
     storageIntegrationTestHelper.tearDown();
   }
 

--- a/java/src/test/java/com/google/appengine/tools/mapreduce/servlets/ShufflerServletTest.java
+++ b/java/src/test/java/com/google/appengine/tools/mapreduce/servlets/ShufflerServletTest.java
@@ -42,6 +42,7 @@ import com.google.apphosting.api.ApiProxy;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.TreeMultimap;
 
+import lombok.Getter;
 import org.junit.*;
 import org.junit.runner.RunWith;
 import org.junit.runners.BlockJUnit4ClassRunner;
@@ -124,10 +125,11 @@ public class ShufflerServletTest {
     }
   }
 
-  CloudStorageIntegrationTestHelper storageIntegrationTestHelper;
+  @Getter
+  static CloudStorageIntegrationTestHelper storageIntegrationTestHelper;
 
   @BeforeClass
-  public void setupStorage() {
+  public static void setupStorage() {
     storageIntegrationTestHelper = new CloudStorageIntegrationTestHelper();
     storageIntegrationTestHelper.setUp();
   }
@@ -156,7 +158,7 @@ public class ShufflerServletTest {
   }
 
   @AfterClass
-  public void teardownStorage() {
+  public static void teardownStorage() {
     storageIntegrationTestHelper.tearDown();
   }
 

--- a/java/src/test/java/com/google/appengine/tools/mapreduce/servlets/ShufflerServletTest.java
+++ b/java/src/test/java/com/google/appengine/tools/mapreduce/servlets/ShufflerServletTest.java
@@ -95,7 +95,6 @@ public class ShufflerServletTest {
           .setDisableAutoTaskExecution(false).setCallbackClass(TaskRunner.class),
       new LocalMemcacheServiceTestConfig(), new LocalModulesServiceTestConfig());
 
-
   public static class TaskRunner extends ServletInvokingTaskCallback {
 
     private static final Map<String, HttpServlet> servletMap =
@@ -163,7 +162,7 @@ public class ShufflerServletTest {
 
   @Test
   public void testDataIsOrdered() throws InterruptedException, IOException {
-    ShufflerParams shufflerParams = createParams(3, 10);
+    ShufflerParams shufflerParams = createParams(storageIntegrationTestHelper.getBucket(), 3, 10);
     TreeMultimap<ByteBuffer, ByteBuffer> input = writeInputFiles(shufflerParams, new Random(0));
     PipelineService service = PipelineServiceFactory.newPipelineService();
     ShuffleMapReduce mr = new ShuffleMapReduce(shufflerParams);
@@ -176,7 +175,7 @@ public class ShufflerServletTest {
 
   @Test
   public void testJson() throws IOException {
-    ShufflerParams shufflerParams = createParams(3, 10);
+    ShufflerParams shufflerParams = createParams(storageIntegrationTestHelper.getBucket(), 3, 10);
     Marshaller<ShufflerParams> marshaller =
         Marshallers.getGenericJsonMarshaller(ShufflerParams.class);
     ByteBuffer bytes = marshaller.toBytes(shufflerParams);
@@ -270,7 +269,7 @@ public class ShufflerServletTest {
     return keyValue;
   }
 
-  static ShufflerParams createParams(int inputFiles, int outputShards) {
+  static ShufflerParams createParams(String bucket, int inputFiles, int outputShards) {
     ShufflerParams shufflerParams = new ShufflerParams();
     shufflerParams.setCallbackService("default");
     shufflerParams.setCallbackVersion("callbackVersion");
@@ -283,7 +282,7 @@ public class ShufflerServletTest {
     shufflerParams.setInputFileNames(list.toArray(new String[inputFiles]));
     shufflerParams.setOutputShards(outputShards);
     shufflerParams.setShufflerQueue("default");
-    shufflerParams.setGcsBucket("storageBucket");
+    shufflerParams.setGcsBucket(bucket);
     shufflerParams.setOutputDir("storageDir");
     return shufflerParams;
   }

--- a/java/src/test/java/com/google/appengine/tools/mapreduce/servlets/ShufflerServletTest.java
+++ b/java/src/test/java/com/google/appengine/tools/mapreduce/servlets/ShufflerServletTest.java
@@ -90,9 +90,11 @@ public class ShufflerServletTest {
   private static final Semaphore WAIT_ON = new Semaphore(0);
 
   private final LocalServiceTestHelper helper = new LocalServiceTestHelper(
-      new LocalDatastoreServiceTestConfig(), new LocalTaskQueueTestConfig()
-          .setDisableAutoTaskExecution(false).setCallbackClass(TaskRunner.class),
-      new LocalMemcacheServiceTestConfig(), new LocalModulesServiceTestConfig());
+      new LocalDatastoreServiceTestConfig(),
+      new LocalTaskQueueTestConfig().setDisableAutoTaskExecution(false).setCallbackClass(TaskRunner.class),
+      new LocalMemcacheServiceTestConfig(),
+      new LocalModulesServiceTestConfig()
+  );
 
   public static class TaskRunner extends ServletInvokingTaskCallback {
 

--- a/java/src/test/java/com/google/appengine/tools/mapreduce/servlets/ShufflerServletTest.java
+++ b/java/src/test/java/com/google/appengine/tools/mapreduce/servlets/ShufflerServletTest.java
@@ -183,7 +183,7 @@ public class ShufflerServletTest {
     assertEquals(shufflerParams.getOutputDir(), readShufflerParams.getOutputDir());
     assertEquals(shufflerParams.getOutputShards(), readShufflerParams.getOutputShards());
     assertEquals(shufflerParams.getCallbackQueue(), readShufflerParams.getCallbackQueue());
-    assertEquals(shufflerParams.getCallbackModule(), readShufflerParams.getCallbackModule());
+    assertEquals(shufflerParams.getCallbackService(), readShufflerParams.getCallbackService());
     assertEquals(shufflerParams.getCallbackVersion(), readShufflerParams.getCallbackVersion());
     assertEquals(shufflerParams.getCallbackPath(), readShufflerParams.getCallbackPath());
   }
@@ -263,7 +263,7 @@ public class ShufflerServletTest {
 
   static ShufflerParams createParams(int inputFiles, int outputShards) {
     ShufflerParams shufflerParams = new ShufflerParams();
-    shufflerParams.setCallbackModule("default");
+    shufflerParams.setCallbackService("default");
     shufflerParams.setCallbackVersion("callbackVersion");
     shufflerParams.setCallbackPath(CALLBACK_PATH);
     shufflerParams.setCallbackQueue("default");

--- a/java/src/test/java/com/google/appengine/tools/mapreduce/servlets/ShufflerServletTest.java
+++ b/java/src/test/java/com/google/appengine/tools/mapreduce/servlets/ShufflerServletTest.java
@@ -239,7 +239,7 @@ public class ShufflerServletTest {
     TreeMultimap<ByteBuffer, ByteBuffer> result = TreeMultimap.create(comparator, comparator);
     for (String fileName : shufflerParams.getInputFileNames()) {
       LevelDbOutputWriter writer = new LevelDbOutputWriter(new GoogleCloudStorageFileOutputWriter(
-          new GcsFilename(shufflerParams.getGcsBucket(), fileName), "testData"));
+          new GcsFilename(shufflerParams.getGcsBucket(), fileName), "testData", GoogleCloudStorageFileOutputWriter.BaseOptions.defaults()));
       writer.beginShard();
       writer.beginSlice();
       for (int i = 0; i < recordsPerFile; i++) {

--- a/java/src/test/java/com/google/appengine/tools/mapreduce/servlets/ShufflerServletTest.java
+++ b/java/src/test/java/com/google/appengine/tools/mapreduce/servlets/ShufflerServletTest.java
@@ -39,6 +39,7 @@ import com.google.appengine.tools.pipeline.PipelineService;
 import com.google.appengine.tools.pipeline.PipelineServiceFactory;
 import com.google.appengine.tools.pipeline.impl.servlets.PipelineServlet;
 import com.google.apphosting.api.ApiProxy;
+import com.google.auth.Credentials;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.TreeMultimap;
 
@@ -171,7 +172,7 @@ public class ShufflerServletTest {
 
   @Test
   public void testDataIsOrdered() throws InterruptedException, IOException {
-    ShufflerParams shufflerParams = createParams(storageIntegrationTestHelper.getBucket(), 3, 10);
+    ShufflerParams shufflerParams = createParams(storageIntegrationTestHelper.getCredentials(), storageIntegrationTestHelper.getBucket(), 3, 10);
     TreeMultimap<ByteBuffer, ByteBuffer> input = writeInputFiles(shufflerParams, new Random(0));
     PipelineService service = PipelineServiceFactory.newPipelineService();
     ShuffleMapReduce mr = new ShuffleMapReduce(shufflerParams);
@@ -184,7 +185,7 @@ public class ShufflerServletTest {
 
   @Test
   public void testJson() throws IOException {
-    ShufflerParams shufflerParams = createParams(storageIntegrationTestHelper.getBucket(), 3, 10);
+    ShufflerParams shufflerParams = createParams(storageIntegrationTestHelper.getCredentials(), storageIntegrationTestHelper.getBucket(), 3, 10);
     Marshaller<ShufflerParams> marshaller =
         Marshallers.getGenericJsonMarshaller(ShufflerParams.class);
     ByteBuffer bytes = marshaller.toBytes(shufflerParams);
@@ -199,6 +200,7 @@ public class ShufflerServletTest {
     assertEquals(shufflerParams.getCallbackService(), readShufflerParams.getCallbackService());
     assertEquals(shufflerParams.getCallbackVersion(), readShufflerParams.getCallbackVersion());
     assertEquals(shufflerParams.getCallbackPath(), readShufflerParams.getCallbackPath());
+    assertEquals(shufflerParams.getCredentials(), readShufflerParams.getCredentials());
   }
 
   private void assertExpectedOutput(TreeMultimap<ByteBuffer, ByteBuffer> expected,
@@ -278,7 +280,7 @@ public class ShufflerServletTest {
     return keyValue;
   }
 
-  static ShufflerParams createParams(String bucket, int inputFiles, int outputShards) {
+  static ShufflerParams createParams(Credentials credentials, String bucket, int inputFiles, int outputShards) {
     ShufflerParams shufflerParams = new ShufflerParams();
     shufflerParams.setCallbackService("default");
     shufflerParams.setCallbackVersion("callbackVersion");
@@ -293,6 +295,7 @@ public class ShufflerServletTest {
     shufflerParams.setShufflerQueue("default");
     shufflerParams.setGcsBucket(bucket);
     shufflerParams.setOutputDir("storageDir");
+    shufflerParams.setCredentials(credentials);
     return shufflerParams;
   }
 

--- a/java/src/test/java/com/google/appengine/tools/mapreduce/servlets/ShufflerServletTest.java
+++ b/java/src/test/java/com/google/appengine/tools/mapreduce/servlets/ShufflerServletTest.java
@@ -126,12 +126,11 @@ public class ShufflerServletTest {
   }
 
   @Getter
-  static CloudStorageIntegrationTestHelper storageIntegrationTestHelper;
+  CloudStorageIntegrationTestHelper storageIntegrationTestHelper;
 
   @BeforeClass
   public static void setupStorage() {
-    storageIntegrationTestHelper = new CloudStorageIntegrationTestHelper();
-    storageIntegrationTestHelper.setUp();
+
   }
 
   @Before
@@ -141,6 +140,8 @@ public class ShufflerServletTest {
     // Creating files is not allowed in some test execution environments, so don't.
     proxy.setProperty(LocalBlobstoreService.NO_STORAGE_PROPERTY, "true");
     WAIT_ON.drainPermits();
+    storageIntegrationTestHelper = new CloudStorageIntegrationTestHelper();
+    storageIntegrationTestHelper.setUp();
   }
 
 
@@ -155,12 +156,9 @@ public class ShufflerServletTest {
       Thread.sleep(1000);
     }
     helper.tearDown();
-  }
-
-  @AfterClass
-  public static void teardownStorage() {
     storageIntegrationTestHelper.tearDown();
   }
+
 
   private int getQueueDepth() {
     return LocalTaskQueueTestConfig

--- a/java/src/test/java/com/google/appengine/tools/mapreduce/servlets/ShufflerServletTest.java
+++ b/java/src/test/java/com/google/appengine/tools/mapreduce/servlets/ShufflerServletTest.java
@@ -171,7 +171,7 @@ public class ShufflerServletTest {
 
   @Test
   public void testDataIsOrdered() throws InterruptedException, IOException {
-    ShufflerParams shufflerParams = createParams(storageIntegrationTestHelper.getBase64EncodedServiceAccountKey(), storageIntegrationTestHelper.getBucket(), 3, 10);
+    ShufflerParams shufflerParams = createParams(storageIntegrationTestHelper.getBase64EncodedServiceAccountKey(), storageIntegrationTestHelper.getBucket(), 3, 2);
     TreeMultimap<ByteBuffer, ByteBuffer> input = writeInputFiles(shufflerParams, new Random(0));
     PipelineService service = PipelineServiceFactory.newPipelineService();
     ShuffleMapReduce mr = new ShuffleMapReduce(shufflerParams);
@@ -184,7 +184,7 @@ public class ShufflerServletTest {
 
   @Test
   public void testJson() throws IOException {
-    ShufflerParams shufflerParams = createParams(storageIntegrationTestHelper.getBase64EncodedServiceAccountKey(), storageIntegrationTestHelper.getBucket(), 3, 10);
+    ShufflerParams shufflerParams = createParams(storageIntegrationTestHelper.getBase64EncodedServiceAccountKey(), storageIntegrationTestHelper.getBucket(), 3, 2);
     Marshaller<ShufflerParams> marshaller =
         Marshallers.getGenericJsonMarshaller(ShufflerParams.class);
     ByteBuffer bytes = marshaller.toBytes(shufflerParams);

--- a/java/src/test/java/com/google/appengine/tools/mapreduce/servlets/ShufflerServletTest.java
+++ b/java/src/test/java/com/google/appengine/tools/mapreduce/servlets/ShufflerServletTest.java
@@ -20,7 +20,6 @@ import static org.junit.Assert.assertTrue;
 
 import com.google.appengine.api.blobstore.dev.LocalBlobstoreService;
 import com.google.appengine.api.taskqueue.QueueFactory;
-import com.google.appengine.tools.cloudstorage.GcsFilename;
 import com.google.appengine.tools.development.ApiProxyLocal;
 import com.google.appengine.tools.development.testing.LocalDatastoreServiceTestConfig;
 import com.google.appengine.tools.development.testing.LocalMemcacheServiceTestConfig;
@@ -28,10 +27,7 @@ import com.google.appengine.tools.development.testing.LocalModulesServiceTestCon
 import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
 import com.google.appengine.tools.development.testing.LocalTaskQueueTestConfig;
 import com.google.appengine.tools.development.testing.LocalTaskQueueTestConfig.ServletInvokingTaskCallback;
-import com.google.appengine.tools.mapreduce.KeyValue;
-import com.google.appengine.tools.mapreduce.MapReduceServlet;
-import com.google.appengine.tools.mapreduce.Marshaller;
-import com.google.appengine.tools.mapreduce.Marshallers;
+import com.google.appengine.tools.mapreduce.*;
 import com.google.appengine.tools.mapreduce.impl.sort.LexicographicalComparator;
 import com.google.appengine.tools.mapreduce.inputs.GoogleCloudStorageLevelDbInputReader;
 import com.google.appengine.tools.mapreduce.outputs.GoogleCloudStorageFileOutputWriter;

--- a/java/src/test/java/com/google/appengine/tools/mapreduce/servlets/ShufflerServletTest.java
+++ b/java/src/test/java/com/google/appengine/tools/mapreduce/servlets/ShufflerServletTest.java
@@ -30,6 +30,7 @@ import com.google.appengine.tools.development.testing.LocalTaskQueueTestConfig.S
 import com.google.appengine.tools.mapreduce.*;
 import com.google.appengine.tools.mapreduce.impl.sort.LexicographicalComparator;
 import com.google.appengine.tools.mapreduce.inputs.GoogleCloudStorageLevelDbInputReader;
+import com.google.appengine.tools.mapreduce.outputs.GoogleCloudStorageFileOutput;
 import com.google.appengine.tools.mapreduce.outputs.GoogleCloudStorageFileOutputWriter;
 import com.google.appengine.tools.mapreduce.outputs.LevelDbOutputWriter;
 import com.google.appengine.tools.mapreduce.servlets.ShufflerServlet.ShuffleMapReduce;
@@ -235,7 +236,7 @@ public class ShufflerServletTest {
     TreeMultimap<ByteBuffer, ByteBuffer> result = TreeMultimap.create(comparator, comparator);
     for (String fileName : shufflerParams.getInputFileNames()) {
       LevelDbOutputWriter writer = new LevelDbOutputWriter(new GoogleCloudStorageFileOutputWriter(
-          new GcsFilename(shufflerParams.getGcsBucket(), fileName), "testData", GoogleCloudStorageFileOutputWriter.BaseOptions.defaults()));
+          new GcsFilename(shufflerParams.getGcsBucket(), fileName), "testData", GoogleCloudStorageFileOutput.BaseOptions.defaults()));
       writer.beginShard();
       writer.beginSlice();
       for (int i = 0; i < recordsPerFile; i++) {


### PR DESCRIPTION
Obviously, worth testing in staging for our org; compare counters for various jobs against same runs in prod and make sure all looks the same. That said, Google does have this pretty well-covered with tests - many of which I had to fix to get this all working.

My biggest area of concern is the slice/shard retries behave OK; but again, seem lots of tests targeted at this.

### Features
  - [upgrade GCS lib in GAE MR fw](https://app.asana.com/0/1184913532255487/1185515139111693) - specifically use the new one, which uses REST API; avoids GAE built-ins, will support encrypted buckets so we can allocate one per-customer

### Change implications

 - breaking change to API? **yes**
 - changes dependencies?  **yes**
