### PR TITLE
s96 : fix ConcatenatingInputReader

### DIFF
--- a/java/src/main/java/com/google/appengine/tools/mapreduce/inputs/ConcatenatingInputReader.java
+++ b/java/src/main/java/com/google/appengine/tools/mapreduce/inputs/ConcatenatingInputReader.java
@@ -1,6 +1,7 @@
 package com.google.appengine.tools.mapreduce.inputs;
 
 import com.google.appengine.tools.mapreduce.InputReader;
+import com.google.appengine.tools.mapreduce.ShardContext;
 import com.google.common.base.Preconditions;
 
 import java.io.IOException;
@@ -27,7 +28,6 @@ public final class ConcatenatingInputReader<I> extends InputReader<I> {
 
   @Override
   public void setContext(ShardContext context) {
-    super.setContext(context);
     this.readers.forEach(r -> r.setContext(context));
   }
 

--- a/java/src/main/java/com/google/appengine/tools/mapreduce/inputs/ConcatenatingInputReader.java
+++ b/java/src/main/java/com/google/appengine/tools/mapreduce/inputs/ConcatenatingInputReader.java
@@ -26,6 +26,12 @@ public final class ConcatenatingInputReader<I> extends InputReader<I> {
   }
 
   @Override
+  public void setContext(ShardContext context) {
+    super.setContext(context);
+    this.readers.forEach(r -> r.setContext(context));
+  }
+
+  @Override
   public void beginSlice() throws IOException {
     if (reader != null) {
       reader.beginSlice();


### PR DESCRIPTION

### Fixes
 - `ConcatenatingInputReader` doesn't populate its context onto the `InputReader`(s) it wraps


### Change implications

 - breaking change to API? **no**
 - changes dependencies?  **no**
