### PR TITLE
S100 remove sneaky throws

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -11,7 +11,7 @@
   </organization>
   <!-- follow semver for fork of OSS -->
   <!-- https://gofore.com/en/best-practices-for-forking-a-git-repo/ -->
-  <version>0.10+worklytics.4</version>
+  <version>0.10+worklytics.5</version>
   <packaging>jar</packaging>
   <scm>
     <connection>scm:git:git@github.com:Worklytics/appengine-mapreduce.git</connection>
@@ -31,7 +31,8 @@
   </licenses>
   <properties>
     <!-- 1.9.72 as min (2019 version) -->
-    <appengine.target.version>[1.9.72,2.0)</appengine.target.version>
+    <!-- 1.9.80 is max supported by app for now -->
+    <appengine.target.version>[1.9.72,1.9.81)</appengine.target.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <github.global.server>github</github.global.server>
@@ -97,7 +98,7 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.8.1</version>
         <configuration>
-          <source>1.8</source> <!-- GAE doesn't support java7 from March 2019 -->
+          <source>1.8</source>
           <target>1.8</target>
           <release>8</release>
         </configuration>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -26,7 +26,7 @@
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0</url>
     </license>
   </licenses>
   <properties>
@@ -61,7 +61,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.1.1</version>
+        <version>3.3.0</version>
         <reportSets>
           <reportSet>
             <id>html</id>

--- a/java/src/main/java/com/google/appengine/tools/mapreduce/MapReduceSettings.java
+++ b/java/src/main/java/com/google/appengine/tools/mapreduce/MapReduceSettings.java
@@ -84,7 +84,6 @@ public class MapReduceSettings extends MapSettings implements GcpCredentialOptio
 
     public Builder() {}
 
-    @SneakyThrows
     public Builder(MapReduceSettings settings) {
       super(settings);
       this.bucketName = settings.bucketName;

--- a/java/src/main/java/com/google/appengine/tools/mapreduce/RetryExecutor.java
+++ b/java/src/main/java/com/google/appengine/tools/mapreduce/RetryExecutor.java
@@ -1,0 +1,19 @@
+package com.google.appengine.tools.mapreduce;
+
+import com.github.rholder.retry.RetryException;
+import com.github.rholder.retry.RetryerBuilder;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+
+public class RetryExecutor {
+
+  public static <V> V call(RetryerBuilder<V> retryerBuilder, Callable<V> callable) {
+    try {
+      return retryerBuilder.build().call(callable);
+    } catch (ExecutionException | RetryException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+}

--- a/java/src/main/java/com/google/appengine/tools/mapreduce/RetryExecutor.java
+++ b/java/src/main/java/com/google/appengine/tools/mapreduce/RetryExecutor.java
@@ -11,7 +11,9 @@ public class RetryExecutor {
   public static <V> V call(RetryerBuilder<V> retryerBuilder, Callable<V> callable) {
     try {
       return retryerBuilder.build().call(callable);
-    } catch (ExecutionException | RetryException e) {
+    } catch (ExecutionException e) {
+      throw new RuntimeException(e.getCause());
+    } catch (RetryException e) {
       throw new RuntimeException(e);
     }
   }

--- a/java/src/main/java/com/google/appengine/tools/mapreduce/impl/shardedjob/ShardedJobRunner.java
+++ b/java/src/main/java/com/google/appengine/tools/mapreduce/impl/shardedjob/ShardedJobRunner.java
@@ -8,6 +8,7 @@ import static com.google.appengine.tools.mapreduce.impl.shardedjob.Status.Status
 import static java.util.concurrent.Executors.callable;
 
 import com.github.rholder.retry.RetryerBuilder;
+import com.github.rholder.retry.StopStrategies;
 import com.github.rholder.retry.WaitStrategies;
 import com.github.rholder.retry.WaitStrategy;
 import com.google.appengine.api.datastore.CommittedButStillApplyingException;
@@ -28,6 +29,7 @@ import com.google.appengine.api.taskqueue.QueueFactory;
 import com.google.appengine.api.taskqueue.TaskOptions;
 import com.google.appengine.api.taskqueue.TransactionalTaskException;
 import com.google.appengine.api.taskqueue.TransientFailureException;
+import com.google.appengine.tools.mapreduce.RetryExecutor;
 import com.google.appengine.tools.mapreduce.impl.shardedjob.Status.StatusCode;
 import com.google.appengine.tools.mapreduce.impl.shardedjob.pipeline.DeleteShardedJob;
 import com.google.appengine.tools.mapreduce.impl.shardedjob.pipeline.FinalizeShardedJob;
@@ -101,33 +103,26 @@ public class ShardedJobRunner<T extends IncrementalTask> implements ShardedJobHa
   public static RetryerBuilder getRetryerBuilder() {
     return RetryerBuilder.newBuilder()
       .withWaitStrategy(WaitStrategies.exponentialWait(30_000, TimeUnit.MILLISECONDS))
-      .retryIfException(e -> {
-        boolean ofTypeToRetryFor =
-          e instanceof ApiProxyException
-            || e instanceof ConcurrentModificationException
-            || e instanceof DatastoreFailureException
-            || e instanceof CommittedButStillApplyingException
-            || e instanceof DatastoreTimeoutException
-            || e instanceof TransientFailureException
-            || e instanceof TransactionalTaskException;
-
-        boolean ofTypeToStopFor = e instanceof RequestTooLargeException
-          || e instanceof ResponseTooLargeException
-          || e instanceof ArgumentException;
-
-        return ofTypeToRetryFor && !ofTypeToStopFor;
-      });
+      .withStopStrategy(StopStrategies.stopAfterAttempt(8))
+      .retryIfExceptionOfType(ApiProxyException.class)
+      .retryIfExceptionOfType(ConcurrentModificationException.class)
+      .retryIfExceptionOfType(DatastoreFailureException.class)
+      .retryIfExceptionOfType(CommittedButStillApplyingException.class)
+      .retryIfExceptionOfType(DatastoreTimeoutException.class)
+      .retryIfExceptionOfType(TransientFailureException.class)
+      .retryIfExceptionOfType(TransactionalTaskException.class);
   }
 
   public static RetryerBuilder getRetryerBuilderAggressive() {
       return RetryerBuilder.newBuilder()
         .withWaitStrategy(WaitStrategies.exponentialWait(30_000, TimeUnit.MILLISECONDS))
+        .withStopStrategy(StopStrategies.stopAfterAttempt(8))
         .retryIfException(e ->
           !(e instanceof RequestTooLargeException
             || e instanceof ResponseTooLargeException
             || e instanceof ArgumentException
             || e instanceof DeadlineExceededException));
-    }
+  }
 
 
 
@@ -226,37 +221,31 @@ public class ShardedJobRunner<T extends IncrementalTask> implements ShardedJobHa
     QueueFactory.getQueue(settings.getQueueName()).add(tx, taskOptions);
   }
 
-  @SneakyThrows
   @Override
   public void completeShard(final String jobId, final String taskId) {
     log.info("Polling task states for job " + jobId);
     final int shardNumber = parseTaskNumberFromTaskId(jobId, taskId);
-    ShardedJobStateImpl<T> jobState = (ShardedJobStateImpl<T>) getRetryerBuilder()
-      .build().call(new Callable<ShardedJobStateImpl<T>>() {
-        @Override
-        public ShardedJobStateImpl<T> call() throws ConcurrentModificationException,
-          DatastoreFailureException {
-          Transaction tx = DATASTORE.beginTransaction();
-          try {
-            ShardedJobStateImpl<T> jobState = lookupJobState(tx, jobId);
-            if (jobState == null) {
-              return null;
-            }
-            jobState.setMostRecentUpdateTimeMillis(
-              Math.max(System.currentTimeMillis(), jobState.getMostRecentUpdateTimeMillis()));
-            jobState.markShardCompleted(shardNumber);
-
-            if (jobState.getActiveTaskCount() == 0 && jobState.getStatus().isActive()) {
-              jobState.setStatus(new Status(DONE));
-            }
-            DATASTORE.put(tx, ShardedJobStateImpl.ShardedJobSerializer.toEntity(tx, jobState));
-            tx.commit();
-            return jobState;
-          } finally {
-            rollbackIfActive(tx);
-          }
+    ShardedJobStateImpl<T> jobState = (ShardedJobStateImpl<T>) RetryExecutor.call(getRetryerBuilder(), () -> {
+      Transaction tx = DATASTORE.beginTransaction();
+      try {
+        ShardedJobStateImpl<T> jobState1 = lookupJobState(tx, jobId);
+        if (jobState1 == null) {
+          return null;
         }
-      });
+        jobState1.setMostRecentUpdateTimeMillis(
+          Math.max(System.currentTimeMillis(), jobState1.getMostRecentUpdateTimeMillis()));
+        jobState1.markShardCompleted(shardNumber);
+
+        if (jobState1.getActiveTaskCount() == 0 && jobState1.getStatus().isActive()) {
+          jobState1.setStatus(new Status(DONE));
+        }
+        DATASTORE.put(tx, ShardedJobStateImpl.ShardedJobSerializer.toEntity(tx, jobState1));
+        tx.commit();
+        return jobState1;
+      } finally {
+        rollbackIfActive(tx);
+      }
+    });
 
     if (jobState == null) {
       log.info(taskId + ": Job is gone, ignoring completeShard call.");
@@ -481,14 +470,15 @@ public class ShardedJobRunner<T extends IncrementalTask> implements ShardedJobHa
     taskState.incrementAndGetRetryCount(); // trigger saving the last task instead of current
   }
 
-  @SneakyThrows
   private void updateTask(final ShardedJobStateImpl<T> jobState,
       final IncrementalTaskState<T> taskState, /* Nullable */
       final ShardRetryState<T> shardRetryState, boolean aggressiveRetry) {
     taskState.setSequenceNumber(taskState.getSequenceNumber() + 1);
     taskState.getLockInfo().unlock();
+
+    @SuppressWarnings("rawtypes")
     RetryerBuilder exceptionHandler = aggressiveRetry ? getRetryerBuilderAggressive() : getRetryerBuilder();
-    exceptionHandler.build().call(
+    RetryExecutor.call(exceptionHandler,
       callable(new Runnable() {
         @Override
         public void run() {
@@ -654,7 +644,6 @@ public class ShardedJobRunner<T extends IncrementalTask> implements ShardedJobHa
     changeJobStatus(jobId, new Status(ABORTED));
   }
 
-  @SneakyThrows
   boolean cleanupJob(String jobId) {
     ShardedJobStateImpl<T> jobState = lookupJobState(null, jobId);
     if (jobState == null) {
@@ -670,7 +659,7 @@ public class ShardedJobRunner<T extends IncrementalTask> implements ShardedJobHa
     }
     final Key jobKey = ShardedJobStateImpl.ShardedJobSerializer.makeKey(jobId);
 
-    getRetryerBuilder().build().call(callable(() -> DATASTORE.delete(jobKey)));
+    RetryExecutor.call(getRetryerBuilder(), callable(() -> DATASTORE.delete(jobKey)));
     return true;
   }
 }

--- a/java/src/main/java/com/google/appengine/tools/mapreduce/inputs/DatastoreShardStrategy.java
+++ b/java/src/main/java/com/google/appengine/tools/mapreduce/inputs/DatastoreShardStrategy.java
@@ -29,6 +29,7 @@ import com.google.appengine.api.datastore.Query.FilterOperator;
 import com.google.appengine.api.datastore.Query.FilterPredicate;
 import com.google.appengine.api.datastore.Query.SortDirection;
 import com.google.appengine.api.datastore.Rating;
+import com.google.appengine.tools.mapreduce.RetryExecutor;
 import com.google.appengine.tools.mapreduce.impl.util.SerializationUtil;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
@@ -398,10 +399,10 @@ public class DatastoreShardStrategy {
     return new FilterPredicate(propertyName, operator, item.get(0).getProperty(propertyName));
   }
 
-  @SneakyThrows
   private List<Entity> runQuery(Query q, final int limit) {
     final PreparedQuery preparedQuery = datastore.prepare(q);
-    return (List<Entity>) getRetryerBuilder().build().call(() -> {
+    //noinspection unchecked
+    return (List<Entity>) RetryExecutor.call(getRetryerBuilder(), () -> {
         List<Entity> list = preparedQuery.asList(withLimit(limit));
         list.size(); // Forces the loading of all the data.
         return list;

--- a/java/src/main/java/com/google/appengine/tools/mapreduce/servlets/ShufflerServlet.java
+++ b/java/src/main/java/com/google/appengine/tools/mapreduce/servlets/ShufflerServlet.java
@@ -225,10 +225,9 @@ public class ShufflerServlet extends HttpServlet {
   /**
    * Notifies the caller that the job has completed.
    */
-  @SneakyThrows
   private static void enqueueCallbackTask(final ShufflerParams shufflerParams, final String url,
                                           final String taskName) {
-    getRetryerBuilder().build().call(callable(() -> {
+    RetryExecutor.call(getRetryerBuilder(), callable(() -> {
         String hostname = ModulesServiceFactory.getModulesService().getVersionHostname(
             shufflerParams.getCallbackService(), shufflerParams.getCallbackVersion());
         Queue queue = QueueFactory.getQueue(shufflerParams.getCallbackQueue());


### PR DESCRIPTION
Hunt for clues to understand why Asana job is stopping. More info on the task.
So far this does not fixes the halt, but at least fixes exception handling and one missing stop strategy in the retryer that caused this to hang.
Removes Lombok's `SneakyThrows` too just in case something was going wrong there.

### Fixes
- [Asana fetch items stopped](https://app.asana.com/0/1200032038751930/1200533691178265)

### Change implications

 - breaking change to API? **no**
 - changes dependencies?  **yes** (limits app-engine to same version as we use in worklytics)
